### PR TITLE
Add ResultHandler behaviour for processing analysis results

### DIFF
--- a/lib/beamlens.ex
+++ b/lib/beamlens.ex
@@ -35,6 +35,7 @@ defmodule Beamlens do
 
     * `:schedules` - List of schedule configurations (see below)
     * `:agent_opts` - Global options passed to all agent runs
+    * `:result_handler` - Module implementing `Beamlens.ResultHandler` to receive results
 
   ### Schedule Configuration
 
@@ -56,7 +57,8 @@ defmodule Beamlens do
         agent_opts: [
           timeout: 60_000,
           max_iterations: 10
-        ]}
+        ],
+        result_handler: MyApp.BeamlensHandler}
 
   ## Manual Usage
 

--- a/lib/beamlens/result_handler.ex
+++ b/lib/beamlens/result_handler.ex
@@ -1,0 +1,48 @@
+defmodule Beamlens.ResultHandler do
+  @moduledoc """
+  Behaviour for handling agent results.
+
+  Implement this behaviour to react to health analysis results,
+  such as sending alerts, storing to a database, or triggering actions.
+
+  ## Example
+
+      defmodule MyApp.AlertHandler do
+        @behaviour Beamlens.ResultHandler
+
+        alias Beamlens.HealthAnalysis
+
+        def handle_result(%HealthAnalysis{status: :critical} = analysis, opts) do
+          MyApp.PagerDuty.alert(analysis.summary, severity: :high, trace_id: opts[:trace_id])
+          :ok
+        end
+
+        def handle_result(%HealthAnalysis{status: :warning} = analysis, _opts) do
+          MyApp.Slack.notify("#ops", analysis.summary)
+          :ok
+        end
+
+        def handle_result(%HealthAnalysis{status: :healthy}, _opts), do: :ok
+      end
+
+  Configure in your supervision tree:
+
+      {Beamlens,
+        schedules: [{:default, "*/5 * * * *"}],
+        result_handler: MyApp.AlertHandler}
+
+  ## Callback Options
+
+  The `opts` keyword list includes:
+
+    * `:trace_id` - Correlation ID for the agent run
+    * `:node` - Node where the analysis ran
+    * `:schedule` - Schedule name (only for scheduled runs)
+    * `:duration_ms` - Time taken for the analysis in milliseconds
+  """
+
+  alias Beamlens.HealthAnalysis
+
+  @callback handle_result(analysis :: HealthAnalysis.t(), opts :: keyword()) ::
+              :ok | {:error, term()}
+end


### PR DESCRIPTION
Introduces a callback-based system for handling agent results. Users
can implement the Beamlens.ResultHandler behaviour to react to health
analyses (e.g., send alerts, persist to DB, notify external services).

The handler receives the HealthAnalysis struct along with metadata
including trace_id, node, schedule name, and duration.