### PR TITLE
Add Google AI provider support for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Google AI (Gemini) provider support for integration tests via `BEAMLENS_TEST_PROVIDER=google-ai`
+
+### Fixed
+
+- Unit tests no longer make LLM provider calls
+- Eval tests now respect `BEAMLENS_TEST_PROVIDER` configuration
+- `OperatorSupervisor.start_operator/2` test uses module-based skill identification
+
 ## [0.2.0] - 2026-01-14
 
 See the updated [README.md](README.md)!

--- a/lib/beamlens.ex
+++ b/lib/beamlens.ex
@@ -59,6 +59,7 @@ defmodule Beamlens do
   By default, BeamLens uses Anthropic (requires `ANTHROPIC_API_KEY` env var).
   Configure a custom provider via `:client_registry` when running investigations:
 
+      # Ollama (local)
       {:ok, result} = Beamlens.Coordinator.run(%{reason: "memory alert"},
         client_registry: %{
           primary: "Ollama",
@@ -71,8 +72,21 @@ defmodule Beamlens do
           ]
         })
 
-  Supported providers include: `anthropic`, `openai`, `openai-generic` (Ollama),
-  `aws-bedrock`, `google-ai`, `azure-openai`, and more.
+      # Google AI (Gemini) - requires GOOGLE_API_KEY env var
+      {:ok, result} = Beamlens.Coordinator.run(%{reason: "memory alert"},
+        client_registry: %{
+          primary: "Gemini",
+          clients: [
+            %{
+              name: "Gemini",
+              provider: "google-ai",
+              options: %{model: "gemini-flash-lite-latest"}
+            }
+          ]
+        })
+
+  Supported providers include: `anthropic`, `openai`, `google-ai`, `openai-generic` (Ollama),
+  `aws-bedrock`, `azure-openai`, and more.
 
   ### Operator Configuration
 

--- a/test/beamlens/coordinator_test.exs
+++ b/test/beamlens/coordinator_test.exs
@@ -1840,101 +1840,8 @@ defmodule Beamlens.CoordinatorTest do
     end
   end
 
-  describe "run/2 - basic execution" do
-    @tag :integration
-    test "spawns coordinator and blocks until completion" do
-      {:ok, result} = Coordinator.run(%{reason: "test"}, timeout: 5000)
-
-      assert is_map(result)
-      assert Map.has_key?(result, :insights)
-      assert Map.has_key?(result, :operator_results)
-    end
-
-    @tag :integration
-    test "returns correct result structure" do
-      {:ok, result} = Coordinator.run(%{reason: "test"}, timeout: 5000)
-
-      assert is_list(result.insights)
-      assert is_list(result.operator_results)
-    end
-  end
-
-  describe "run/2 - context handling" do
-    @tag :integration
-    test "passes context map to coordinator" do
-      {:ok, result} = Coordinator.run(%{reason: "memory alert"}, timeout: 5000)
-
-      assert {:ok, _} = result
-    end
-
-    @tag :integration
-    test "handles empty context map" do
-      {:ok, result} = Coordinator.run(%{}, timeout: 5000)
-
-      assert is_map(result)
-      assert is_list(result.insights)
-    end
-
-    @tag :integration
-    test "run/1 with map delegates to run/2" do
-      {:ok, result} = Coordinator.run(%{reason: "test"})
-
-      assert is_map(result)
-    end
-
-    @tag :integration
-    test "run/1 with keyword list extracts context option" do
-      {:ok, result} = Coordinator.run(context: %{reason: "test"}, timeout: 5000)
-
-      assert is_map(result)
-    end
-  end
-
-  describe "run/2 - options handling" do
-    @tag :integration
-    test "accepts notifications option" do
-      notification = build_test_notification()
-      {:ok, result} = Coordinator.run(%{}, notifications: [notification], timeout: 5000)
-
-      assert is_map(result)
-    end
-
-    @tag :integration
-    test "accepts skills option" do
-      {:ok, result} = Coordinator.run(%{}, skills: [Beamlens.Skill.Beam], timeout: 5000)
-
-      assert is_map(result)
-    end
-
-    @tag :integration
-    test "accepts client_registry option" do
-      registry = %{primary: "Default", clients: []}
-      {:ok, result} = Coordinator.run(%{}, client_registry: registry, timeout: 30_000)
-
-      assert is_map(result)
-    end
-
-    @tag :integration
-    test "accepts max_iterations option" do
-      {:ok, result} = Coordinator.run(%{}, max_iterations: 5, timeout: 5000)
-
-      assert is_map(result)
-    end
-
-    @tag :integration
-    test "accepts compaction options" do
-      {:ok, result} =
-        Coordinator.run(%{},
-          compaction_max_tokens: 10_000,
-          compaction_keep_last: 3,
-          timeout: 5000
-        )
-
-      assert is_map(result)
-    end
-  end
-
   describe "run/2 - timeout behavior" do
+    @tag :live
     test "respects timeout option by exiting" do
       Process.flag(:trap_exit, true)
 
@@ -1945,34 +1852,10 @@ defmodule Beamlens.CoordinatorTest do
 
       assert_receive {:EXIT, ^pid, {:timeout, _}}, 200
     end
-
-    @tag :integration
-    test "uses default timeout when not specified" do
-      {:ok, result} = Coordinator.run(%{reason: "test"})
-
-      assert is_map(result)
-    end
   end
 
   describe "run/2 - process cleanup" do
-    @tag :integration
-    test "coordinator process stops after completion" do
-      {:ok, _result} = Coordinator.run(%{}, timeout: 5000)
-
-      refute Enum.any?(Process.list(), fn pid ->
-               case Process.info(pid, :dictionary) do
-                 {:dictionary, dict} ->
-                   Enum.any?(dict, fn
-                     {:"$initial_call", {Beamlens.Coordinator, :init, 1}} -> true
-                     _ -> false
-                   end)
-
-                 nil ->
-                   false
-               end
-             end)
-    end
-
+    @tag :live
     test "coordinator process stops even when timeout occurs" do
       Process.flag(:trap_exit, true)
       coordinators_before = count_coordinator_processes()

--- a/test/beamlens/integration_case_test.exs
+++ b/test/beamlens/integration_case_test.exs
@@ -1,0 +1,50 @@
+defmodule Beamlens.IntegrationCaseTest do
+  use ExUnit.Case, async: true
+
+  describe "build_client_registry/1 with google-ai" do
+    setup do
+      original_api_key = System.get_env("GOOGLE_API_KEY")
+      original_model = System.get_env("BEAMLENS_TEST_MODEL")
+
+      on_exit(fn ->
+        if original_api_key,
+          do: System.put_env("GOOGLE_API_KEY", original_api_key),
+          else: System.delete_env("GOOGLE_API_KEY")
+
+        if original_model,
+          do: System.put_env("BEAMLENS_TEST_MODEL", original_model),
+          else: System.delete_env("BEAMLENS_TEST_MODEL")
+      end)
+
+      :ok
+    end
+
+    test "builds google-ai registry when GOOGLE_API_KEY is set" do
+      System.put_env("GOOGLE_API_KEY", "test-key")
+      System.delete_env("BEAMLENS_TEST_MODEL")
+
+      assert {:ok, registry} = Beamlens.IntegrationCase.build_client_registry("google-ai")
+      assert registry.primary == "Gemini"
+      assert [client] = registry.clients
+      assert client.name == "Gemini"
+      assert client.provider == "google-ai"
+      assert client.options.model == "gemini-flash-lite-latest"
+    end
+
+    test "returns error when GOOGLE_API_KEY not set" do
+      System.delete_env("GOOGLE_API_KEY")
+
+      assert {:error, message} = Beamlens.IntegrationCase.build_client_registry("google-ai")
+      assert message =~ "GOOGLE_API_KEY not set"
+    end
+
+    test "respects BEAMLENS_TEST_MODEL override for google-ai" do
+      System.put_env("GOOGLE_API_KEY", "test-key")
+      System.put_env("BEAMLENS_TEST_MODEL", "gemini-1.5-pro")
+
+      assert {:ok, registry} = Beamlens.IntegrationCase.build_client_registry("google-ai")
+      assert [client] = registry.clients
+      assert client.options.model == "gemini-1.5-pro"
+    end
+  end
+end

--- a/test/beamlens/operator_test.exs
+++ b/test/beamlens/operator_test.exs
@@ -447,76 +447,10 @@ defmodule Beamlens.OperatorTest do
       assert {:error, {:invalid_skill_module, :nonexistent}} =
                Operator.run(:nonexistent, %{})
     end
-
-    @tag :integration
-    test "accepts valid skill module" do
-      {:ok, notifications} = Operator.run(TestSkill, %{reason: "test"})
-
-      assert is_list(notifications)
-    end
-  end
-
-  describe "run/2 context formatting" do
-    @tag :integration
-    test "formats context with reason" do
-      {:ok, notifications} = Operator.run(TestSkill, %{reason: "memory alert"})
-
-      assert is_list(notifications)
-    end
-
-    @tag :integration
-    test "handles empty context map" do
-      {:ok, notifications} = Operator.run(TestSkill, %{})
-
-      assert is_list(notifications)
-    end
-
-    @tag :integration
-    test "handles context with non-string values" do
-      {:ok, notifications} = Operator.run(TestSkill, %{count: 42, enabled: true})
-
-      assert is_list(notifications)
-    end
-  end
-
-  describe "run/2 options handling" do
-    @tag :integration
-    test "accepts client_registry option" do
-      registry = %{primary: "Default", clients: []}
-      {:ok, notifications} = Operator.run(TestSkill, %{}, client_registry: registry)
-
-      assert is_list(notifications)
-    end
-
-    @tag :integration
-    test "accepts timeout option" do
-      {:ok, notifications} = Operator.run(TestSkill, %{}, timeout: 10_000)
-
-      assert is_list(notifications)
-    end
-
-    @tag :integration
-    test "accepts max_iterations option" do
-      {:ok, notifications} = Operator.run(TestSkill, %{}, max_iterations: 5)
-
-      assert is_list(notifications)
-    end
-
-    @tag :integration
-    test "accepts compaction options" do
-      {:ok, notifications} =
-        Operator.run(
-          TestSkill,
-          %{},
-          compaction_max_tokens: 100_000,
-          compaction_keep_last: 10
-        )
-
-      assert is_list(notifications)
-    end
   end
 
   describe "run/2 timeout behavior" do
+    @tag :live
     test "respects timeout option by exiting" do
       Process.flag(:trap_exit, true)
 
@@ -527,33 +461,10 @@ defmodule Beamlens.OperatorTest do
 
       assert_receive {:EXIT, ^pid, {:timeout, _}}, 200
     end
-
-    @tag :integration
-    test "uses default timeout when not specified" do
-      {:ok, notifications} = Operator.run(TestSkill, %{})
-
-      assert is_list(notifications)
-    end
-  end
-
-  describe "run/2 return structure" do
-    @tag :integration
-    test "returns list of notifications" do
-      {:ok, notifications} = Operator.run(TestSkill, %{})
-
-      assert is_list(notifications)
-    end
   end
 
   describe "run/2 process cleanup" do
-    @tag :integration
-    test "uses Default client when no client_registry configured" do
-      # When no client_registry is provided, the Default client from beamlens.baml is used
-      result = Operator.run(TestSkill, %{})
-
-      assert match?({:ok, _}, result)
-    end
-
+    @tag :live
     test "stops operator process after timeout" do
       Process.flag(:trap_exit, true)
 

--- a/test/evals/lua_sandbox_test.exs
+++ b/test/evals/lua_sandbox_test.exs
@@ -1,11 +1,22 @@
 defmodule Beamlens.Evals.LuaSandboxTest do
   use ExUnit.Case, async: false
 
+  alias Beamlens.IntegrationCase
   alias Beamlens.Operator
   alias Beamlens.Operator.Tools.{Execute, SendNotification, TakeSnapshot}
   alias Puck.Eval.Graders
 
   @moduletag :eval
+
+  setup do
+    case IntegrationCase.build_client_registry() do
+      {:ok, registry} ->
+        {:ok, client_registry: registry}
+
+      {:error, reason} ->
+        flunk(reason)
+    end
+  end
 
   defmodule InvestigationSkill do
     @behaviour Beamlens.Skill
@@ -104,11 +115,17 @@ defmodule Beamlens.Evals.LuaSandboxTest do
   end
 
   describe "lua sandbox eval" do
-    test "elevated metrics trigger investigation using execute tool" do
+    test "elevated metrics trigger investigation using execute tool", context do
       {_output, trajectory} =
         Puck.Eval.collect(
           fn ->
-            {:ok, pid} = Operator.start_link(skill: InvestigationSkill, start_loop: true)
+            {:ok, pid} =
+              Operator.start_link(
+                skill: InvestigationSkill,
+                start_loop: true,
+                client_registry: context.client_registry
+              )
+
             wait_for_execute_and_stop(pid)
             :ok
           end,

--- a/test/integration/coordinator_run_test.exs
+++ b/test/integration/coordinator_run_test.exs
@@ -1,0 +1,168 @@
+defmodule Beamlens.Integration.CoordinatorRunTest do
+  @moduledoc false
+
+  use Beamlens.IntegrationCase, async: false
+
+  alias Beamlens.Coordinator
+  alias Beamlens.Operator.Notification
+
+  defp build_test_notification(overrides \\ %{}) do
+    Notification.new(
+      Map.merge(
+        %{
+          operator: :test,
+          anomaly_type: "test_anomaly",
+          severity: :info,
+          summary: "Test notification",
+          snapshots: []
+        },
+        overrides
+      )
+    )
+  end
+
+  describe "run/2 - basic execution" do
+    @tag timeout: 60_000
+    test "spawns coordinator and blocks until completion", context do
+      {:ok, result} =
+        Coordinator.run(%{reason: "test"},
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+      assert Map.has_key?(result, :insights)
+      assert Map.has_key?(result, :operator_results)
+    end
+
+    @tag timeout: 60_000
+    test "returns correct result structure", context do
+      {:ok, result} =
+        Coordinator.run(%{reason: "test"},
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_list(result.insights)
+      assert is_list(result.operator_results)
+    end
+  end
+
+  describe "run/2 - context handling" do
+    @tag timeout: 60_000
+    test "passes context map to coordinator", context do
+      {:ok, result} =
+        Coordinator.run(%{reason: "memory alert"},
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+
+    @tag timeout: 60_000
+    test "handles empty context map", context do
+      {:ok, result} =
+        Coordinator.run(%{}, client_registry: context.client_registry, timeout: 30_000)
+
+      assert is_map(result)
+      assert is_list(result.insights)
+    end
+
+    @tag timeout: 60_000
+    test "run/1 with keyword list extracts context option", context do
+      {:ok, result} =
+        Coordinator.run(
+          context: %{reason: "test"},
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+  end
+
+  describe "run/2 - options handling" do
+    @tag timeout: 60_000
+    test "accepts notifications option", context do
+      notification = build_test_notification()
+
+      {:ok, result} =
+        Coordinator.run(%{},
+          notifications: [notification],
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+
+    @tag timeout: 60_000
+    test "accepts skills option", context do
+      {:ok, result} =
+        Coordinator.run(%{},
+          skills: [Beamlens.Skill.Beam],
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+
+    @tag timeout: 60_000
+    test "accepts max_iterations option", context do
+      {:ok, result} =
+        Coordinator.run(%{},
+          max_iterations: 5,
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+
+    @tag timeout: 60_000
+    test "accepts compaction options", context do
+      {:ok, result} =
+        Coordinator.run(%{},
+          compaction_max_tokens: 10_000,
+          compaction_keep_last: 3,
+          client_registry: context.client_registry,
+          timeout: 30_000
+        )
+
+      assert is_map(result)
+    end
+  end
+
+  describe "run/2 - timeout behavior" do
+    @tag timeout: 60_000
+    test "completes within default timeout", context do
+      {:ok, result} =
+        Coordinator.run(%{reason: "test"}, client_registry: context.client_registry)
+
+      assert is_map(result)
+    end
+  end
+
+  describe "run/2 - process cleanup" do
+    @tag timeout: 60_000
+    test "coordinator process stops after completion", context do
+      {:ok, _result} =
+        Coordinator.run(%{}, client_registry: context.client_registry, timeout: 30_000)
+
+      refute Enum.any?(Process.list(), fn pid ->
+               case Process.info(pid, :dictionary) do
+                 {:dictionary, dict} ->
+                   Enum.any?(dict, fn
+                     {:"$initial_call", {Beamlens.Coordinator, :init, 1}} -> true
+                     _ -> false
+                   end)
+
+                 nil ->
+                   false
+               end
+             end)
+    end
+  end
+end

--- a/test/integration/operator_run_test.exs
+++ b/test/integration/operator_run_test.exs
@@ -1,0 +1,133 @@
+defmodule Beamlens.Integration.OperatorRunTest do
+  @moduledoc false
+
+  use Beamlens.IntegrationCase, async: false
+
+  alias Beamlens.Operator
+
+  defmodule TestSkill do
+    @behaviour Beamlens.Skill
+
+    def title, do: "Run Test"
+
+    def description, do: "Test skill for Operator.run/2 integration tests"
+
+    def system_prompt, do: "You are a test skill for integration tests."
+
+    def snapshot do
+      %{
+        memory_utilization_pct: 45.0,
+        process_utilization_pct: 10.0,
+        port_utilization_pct: 5.0,
+        atom_utilization_pct: 2.0,
+        scheduler_run_queue: 0,
+        schedulers_online: 8
+      }
+    end
+
+    def callbacks do
+      %{
+        "get_test_value" => fn -> 42 end
+      }
+    end
+
+    def callback_docs do
+      """
+      ### get_test_value()
+      Returns 42
+      """
+    end
+  end
+
+  describe "run/2 skill resolution" do
+    @tag timeout: 60_000
+    test "accepts valid skill module", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{reason: "test"}, client_registry: context.client_registry)
+
+      assert is_list(notifications)
+    end
+  end
+
+  describe "run/2 context formatting" do
+    @tag timeout: 60_000
+    test "formats context with reason", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{reason: "memory alert"},
+          client_registry: context.client_registry
+        )
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "handles empty context map", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{}, client_registry: context.client_registry)
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "handles context with non-string values", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{count: 42, enabled: true},
+          client_registry: context.client_registry
+        )
+
+      assert is_list(notifications)
+    end
+  end
+
+  describe "run/2 options handling" do
+    @tag timeout: 60_000
+    test "accepts timeout option", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{}, client_registry: context.client_registry, timeout: 30_000)
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "accepts max_iterations option", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{}, client_registry: context.client_registry, max_iterations: 5)
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "accepts compaction options", context do
+      {:ok, notifications} =
+        Operator.run(
+          TestSkill,
+          %{},
+          client_registry: context.client_registry,
+          compaction_max_tokens: 100_000,
+          compaction_keep_last: 10
+        )
+
+      assert is_list(notifications)
+    end
+  end
+
+  describe "run/2 timeout behavior" do
+    @tag timeout: 60_000
+    test "completes within default timeout", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{}, client_registry: context.client_registry)
+
+      assert is_list(notifications)
+    end
+  end
+
+  describe "run/2 return structure" do
+    @tag timeout: 60_000
+    test "returns list of notifications", context do
+      {:ok, notifications} =
+        Operator.run(TestSkill, %{}, client_registry: context.client_registry)
+
+      assert is_list(notifications)
+    end
+  end
+end

--- a/test/integration/supervisor_test.exs
+++ b/test/integration/supervisor_test.exs
@@ -11,10 +11,10 @@ defmodule Beamlens.Integration.SupervisorTest do
     {:ok, supervisor: supervisor}
   end
 
-  describe "start_operator/2 with atom spec" do
+  describe "start_operator/2 with module spec" do
     @tag timeout: 30_000
     test "starts builtin beam operator", %{supervisor: supervisor} do
-      result = OperatorSupervisor.start_operator(supervisor, :beam)
+      result = OperatorSupervisor.start_operator(supervisor, Beamlens.Skill.Beam)
 
       assert {:ok, pid} = result
       assert Process.alive?(pid)

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -15,7 +15,7 @@ defmodule Beamlens.IntegrationCase do
 
   Returns `{:ok, registry}` or `{:error, reason}`.
 
-  Provider can be "anthropic", "openai", or "ollama".
+  Provider can be "anthropic", "openai", "google-ai", or "ollama".
   Defaults to BEAMLENS_TEST_PROVIDER env var or "anthropic".
   """
   def build_client_registry(provider \\ nil) do
@@ -126,8 +126,30 @@ defmodule Beamlens.IntegrationCase do
     end
   end
 
+  defp do_build_client_registry("google-ai") do
+    case System.get_env("GOOGLE_API_KEY") do
+      nil ->
+        {:error, "GOOGLE_API_KEY not set. Set it or use BEAMLENS_TEST_PROVIDER=ollama"}
+
+      _key ->
+        model = System.get_env("BEAMLENS_TEST_MODEL", "gemini-flash-lite-latest")
+
+        {:ok,
+         %{
+           primary: "Gemini",
+           clients: [
+             %{
+               name: "Gemini",
+               provider: "google-ai",
+               options: %{model: model}
+             }
+           ]
+         }}
+    end
+  end
+
   defp do_build_client_registry(provider) do
-    {:error, "Unknown provider: #{provider}. Use anthropic, openai, or ollama"}
+    {:error, "Unknown provider: #{provider}. Use anthropic, openai, google-ai, or ollama"}
   end
 
   defp check_ollama_available do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(exclude: [:integration, :eval])
+ExUnit.start(exclude: [:integration, :eval, :live])


### PR DESCRIPTION
## Summary

- Add Google AI (Gemini) as a supported provider for integration and eval tests
- Fix test infrastructure so unit tests never hit LLM providers
- Fix eval tests to respect `BEAMLENS_TEST_PROVIDER` configuration

## Changes

**Test infrastructure:**
- Tag timeout tests with `:live` to exclude from default test run
- Move integration tests to use `IntegrationCase` with `client_registry`
- Update eval tests to pass `client_registry` from `IntegrationCase`

**Provider support:**
- Add `google-ai` provider option in `IntegrationCase.build_client_registry/1`
- Default model: `gemini-flash-lite-latest`

**Bug fixes:**
- Fix `supervisor_test.exs` to use module `Beamlens.Skill.Beam` instead of atom `:beam`

## Usage

```bash
# Unit tests (no LLM calls)
mix test

# Integration tests with Google AI
BEAMLENS_TEST_PROVIDER=google-ai mix test --only integration

# Eval tests with Google AI  
BEAMLENS_TEST_PROVIDER=google-ai mix test --only eval

# Suppress verbose BAML logging
BAML_LOG=error BEAMLENS_TEST_PROVIDER=google-ai mix test --only integration
```

## Test plan

- [x] `mix test` passes with no provider calls
- [x] `mix credo --strict` passes
- [x] `mix dialyzer` passes
- [x] Integration tests run with Google AI provider