### PR TITLE
Fix Exception skill snapshot JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exception skill snapshot data now serializes correctly to JSON
 - Unit tests no longer make LLM provider calls
 - Eval tests now respect `BEAMLENS_TEST_PROVIDER` configuration
 

--- a/lib/beamlens/skill/exception.ex
+++ b/lib/beamlens/skill/exception.ex
@@ -66,17 +66,27 @@ if Code.ensure_loaded?(Tower) do
     @doc """
     High-level exception statistics for quick health assessment.
 
-    Returns counts by kind, level, and top exception types over a 5-minute rolling window.
+    Returns a map with:
+    - `:total_exceptions_5m` - Total exceptions in the 5-minute window
+    - `:by_kind` - Map of counts by exception kind (`:error`, `:exit`, `:throw`, `:message`)
+    - `:by_level` - Map of counts by log level
+    - `:top_exception_types` - List of maps, each with `:type` (string) and `:count` (integer)
+    - `:unique_exception_types` - Count of distinct exception types
     """
     @impl true
     def snapshot do
       stats = ExceptionStore.get_stats()
 
+      top_types =
+        Enum.map(stats.top_types, fn {type, count} ->
+          %{type: type, count: count}
+        end)
+
       %{
         total_exceptions_5m: stats.total_count,
         by_kind: stats.by_kind,
         by_level: stats.by_level,
-        top_exception_types: stats.top_types,
+        top_exception_types: top_types,
         unique_exception_types: stats.type_count
       }
     end

--- a/test/beamlens/skill/exception_test.exs
+++ b/test/beamlens/skill/exception_test.exs
@@ -3,6 +3,8 @@ defmodule Beamlens.Skill.ExceptionTest do
 
   use ExUnit.Case, async: false
 
+  import Beamlens.ExceptionTestHelper
+
   alias Beamlens.Skill.Exception, as: ExceptionDomain
   alias Beamlens.Skill.Exception.ExceptionStore
 
@@ -57,6 +59,48 @@ defmodule Beamlens.Skill.ExceptionTest do
       assert is_map(snapshot.by_level)
       assert is_list(snapshot.top_exception_types)
       assert is_integer(snapshot.unique_exception_types)
+    end
+
+    test "total_exceptions_5m reflects injected exception count" do
+      inject_exception(%RuntimeError{message: "error 1"})
+      inject_exception(%RuntimeError{message: "error 2"})
+      inject_exception(%ArgumentError{message: "error 3"})
+
+      snapshot = ExceptionDomain.snapshot()
+
+      assert snapshot.total_exceptions_5m == 3
+    end
+
+    test "by_kind counts match injected exception kinds" do
+      inject_exception(%RuntimeError{message: "error"}, kind: :error)
+      inject_exception(%RuntimeError{message: "exit"}, kind: :exit)
+      inject_exception(%RuntimeError{message: "exit 2"}, kind: :exit)
+
+      snapshot = ExceptionDomain.snapshot()
+
+      assert snapshot.by_kind.error == 1
+      assert snapshot.by_kind.exit == 2
+    end
+
+    test "top_exception_types includes injected types" do
+      inject_exception(%ArgumentError{message: "arg 1"})
+      inject_exception(%ArgumentError{message: "arg 2"})
+      inject_exception(%RuntimeError{message: "runtime"})
+
+      snapshot = ExceptionDomain.snapshot()
+
+      assert %{type: "ArgumentError", count: 2} in snapshot.top_exception_types
+      assert %{type: "RuntimeError", count: 1} in snapshot.top_exception_types
+    end
+
+    test "unique_exception_types reflects distinct types" do
+      inject_exception(%ArgumentError{message: "arg"})
+      inject_exception(%RuntimeError{message: "runtime"})
+      inject_exception(%KeyError{key: :foo, term: %{}})
+
+      snapshot = ExceptionDomain.snapshot()
+
+      assert snapshot.unique_exception_types == 3
     end
   end
 
@@ -114,6 +158,108 @@ defmodule Beamlens.Skill.ExceptionTest do
       result = callbacks["exception_stacktrace"].("unknown-id")
 
       assert is_nil(result)
+    end
+  end
+
+  describe "callbacks with injected data" do
+    test "exception_stats returns counts matching injected exceptions" do
+      inject_exception(%RuntimeError{message: "error 1"})
+      inject_exception(%RuntimeError{message: "error 2"})
+      inject_exception(%ArgumentError{message: "arg error"}, kind: :exit)
+
+      callbacks = ExceptionDomain.callbacks()
+      stats = callbacks["exception_stats"].()
+
+      assert stats.total_count == 3
+      assert stats.by_kind.error == 2
+      assert stats.by_kind.exit == 1
+    end
+
+    test "exception_recent returns injected exceptions in order" do
+      inject_exception(%RuntimeError{message: "first"})
+      inject_exception(%RuntimeError{message: "second"})
+      inject_exception(%RuntimeError{message: "third"})
+
+      callbacks = ExceptionDomain.callbacks()
+      exceptions = callbacks["exception_recent"].(10, nil)
+
+      assert length(exceptions) == 3
+      messages = Enum.map(exceptions, & &1.message)
+      assert messages == ["first", "second", "third"]
+    end
+
+    test "exception_recent filters by kind correctly" do
+      inject_exception(%RuntimeError{message: "error"}, kind: :error)
+      inject_exception(%RuntimeError{message: "exit"}, kind: :exit)
+      inject_exception(%RuntimeError{message: "throw"}, kind: :throw)
+
+      callbacks = ExceptionDomain.callbacks()
+      error_exceptions = callbacks["exception_recent"].(10, "error")
+      exit_exceptions = callbacks["exception_recent"].(10, "exit")
+
+      assert length(error_exceptions) == 1
+      assert hd(error_exceptions).kind == :error
+
+      assert length(exit_exceptions) == 1
+      assert hd(exit_exceptions).kind == :exit
+    end
+
+    test "exception_by_type finds matching type and excludes others" do
+      inject_exception(%ArgumentError{message: "arg error"})
+      inject_exception(%RuntimeError{message: "runtime error"})
+      inject_exception(%ArgumentError{message: "another arg error"})
+
+      callbacks = ExceptionDomain.callbacks()
+      arg_errors = callbacks["exception_by_type"].("ArgumentError", 10)
+      runtime_errors = callbacks["exception_by_type"].("RuntimeError", 10)
+
+      assert length(arg_errors) == 2
+      assert Enum.all?(arg_errors, &(&1.type == "ArgumentError"))
+
+      assert length(runtime_errors) == 1
+      assert hd(runtime_errors).type == "RuntimeError"
+    end
+
+    test "exception_search matches message patterns" do
+      inject_exception(%RuntimeError{message: "database connection failed"})
+      inject_exception(%RuntimeError{message: "authentication error"})
+      inject_exception(%RuntimeError{message: "database timeout"})
+
+      callbacks = ExceptionDomain.callbacks()
+      results = callbacks["exception_search"].("database", 10)
+
+      assert length(results) == 2
+      assert Enum.all?(results, &String.contains?(&1.message, "database"))
+    end
+
+    test "exception_stacktrace returns stacktrace for known id" do
+      stacktrace = [
+        {MyModule, :my_function, 2, [file: ~c"lib/my_module.ex", line: 42]},
+        {OtherModule, :other_function, 1, [file: ~c"lib/other_module.ex", line: 10]}
+      ]
+
+      event = inject_exception(%RuntimeError{message: "test"}, stacktrace: stacktrace)
+
+      callbacks = ExceptionDomain.callbacks()
+      result = callbacks["exception_stacktrace"].(event.id)
+
+      assert length(result) == 2
+      [first, second] = result
+      assert first.module == "MyModule"
+      assert first.function == "my_function/2"
+      assert first.line == 42
+      assert second.module == "OtherModule"
+    end
+
+    test "exception_recent respects limit" do
+      for i <- 1..10 do
+        inject_exception(%RuntimeError{message: "error #{i}"})
+      end
+
+      callbacks = ExceptionDomain.callbacks()
+      exceptions = callbacks["exception_recent"].(5, nil)
+
+      assert length(exceptions) == 5
     end
   end
 

--- a/test/evals/exception_skill_test.exs
+++ b/test/evals/exception_skill_test.exs
@@ -1,0 +1,118 @@
+defmodule Beamlens.Evals.ExceptionSkillTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+
+  import Beamlens.ExceptionTestHelper
+
+  alias Beamlens.IntegrationCase
+  alias Beamlens.Operator
+  alias Beamlens.Operator.Tools.{Done, SendNotification, TakeSnapshot}
+  alias Beamlens.Skill.Exception, as: ExceptionSkill
+  alias Beamlens.Skill.Exception.ExceptionStore
+  alias Puck.Eval.Graders
+
+  @moduletag :eval
+
+  setup do
+    start_supervised!({ExceptionStore, name: ExceptionStore})
+
+    case IntegrationCase.build_client_registry() do
+      {:ok, registry} ->
+        {:ok, client_registry: registry}
+
+      {:error, reason} ->
+        flunk(reason)
+    end
+  end
+
+  describe "exception skill eval" do
+    test "no exceptions leads to Done without notification", context do
+      {_output, trajectory} =
+        Puck.Eval.collect(
+          fn ->
+            {:ok, pid} =
+              Operator.start_link(
+                skill: ExceptionSkill,
+                start_loop: true,
+                client_registry: context.client_registry
+              )
+
+            wait_for_done_and_stop(pid)
+            :ok
+          end,
+          timeout: 100
+        )
+
+      result =
+        Puck.Eval.grade(nil, trajectory, [
+          Graders.output_produced(TakeSnapshot),
+          Graders.output_not_produced(SendNotification),
+          Graders.output_produced(Done)
+        ])
+
+      assert result.passed?,
+             "Eval failed.\nSteps: #{trajectory.total_steps}\nResults: #{inspect(result.grader_results, pretty: true)}"
+    end
+
+    test "exception spike leads to notification", context do
+      for _ <- 1..10 do
+        inject_exception(
+          %RuntimeError{message: "database connection failed: timeout after 5000ms"},
+          stacktrace: [
+            {MyApp.Database, :query, 2, [file: ~c"lib/my_app/database.ex", line: 42]},
+            {MyApp.UserService, :get_user, 1, [file: ~c"lib/my_app/user_service.ex", line: 15]}
+          ]
+        )
+      end
+
+      {_output, trajectory} =
+        Puck.Eval.collect(
+          fn ->
+            {:ok, pid} =
+              Operator.start_link(
+                skill: ExceptionSkill,
+                start_loop: true,
+                client_registry: context.client_registry
+              )
+
+            wait_for_done_and_stop(pid)
+            :ok
+          end,
+          timeout: 100
+        )
+
+      result =
+        Puck.Eval.grade(nil, trajectory, [
+          Graders.output_produced(TakeSnapshot),
+          Graders.output_produced(SendNotification)
+        ])
+
+      assert result.passed?,
+             "Eval failed.\nSteps: #{trajectory.total_steps}\nResults: #{inspect(result.grader_results, pretty: true)}"
+    end
+  end
+
+  defp wait_for_done_and_stop(pid) do
+    ref = make_ref()
+    parent = self()
+
+    :telemetry.attach(
+      ref,
+      [:beamlens, :operator, :done],
+      fn _event, _measurements, _metadata, _ ->
+        send(parent, {:done_fired, ref})
+      end,
+      nil
+    )
+
+    receive do
+      {:done_fired, ^ref} ->
+        Operator.stop(pid)
+    after
+      60_000 -> raise "Operator did not reach Done action within timeout"
+    end
+
+    :telemetry.detach(ref)
+  end
+end

--- a/test/integration/exception_skill_test.exs
+++ b/test/integration/exception_skill_test.exs
@@ -1,0 +1,59 @@
+defmodule Beamlens.Integration.ExceptionSkillTest do
+  @moduledoc false
+
+  use Beamlens.IntegrationCase, async: false
+
+  import Beamlens.ExceptionTestHelper
+
+  alias Beamlens.Operator
+  alias Beamlens.Skill.Exception, as: ExceptionSkill
+  alias Beamlens.Skill.Exception.ExceptionStore
+
+  setup do
+    start_supervised!({ExceptionStore, name: ExceptionStore})
+    :ok
+  end
+
+  describe "Exception skill operator" do
+    @tag timeout: 60_000
+    test "runs and completes with empty exception store", context do
+      {:ok, pid} = start_operator(context, skill: ExceptionSkill)
+      {:ok, notifications} = Operator.run(pid, %{}, [])
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "runs and completes with exceptions present", context do
+      inject_exception(%RuntimeError{message: "database connection failed"})
+      inject_exception(%RuntimeError{message: "database timeout"})
+
+      {:ok, pid} = start_operator(context, skill: ExceptionSkill)
+      {:ok, notifications} = Operator.run(pid, %{}, [])
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "runs with context reason", context do
+      inject_exception(%RuntimeError{message: "test error"})
+
+      {:ok, pid} = start_operator(context, skill: ExceptionSkill)
+      {:ok, notifications} = Operator.run(pid, %{reason: "exception spike detected"}, [])
+
+      assert is_list(notifications)
+    end
+
+    @tag timeout: 60_000
+    test "runs with multiple exception types", context do
+      inject_exception(%RuntimeError{message: "runtime error"})
+      inject_exception(%ArgumentError{message: "argument error"})
+      inject_exception(%KeyError{key: :missing, term: %{}})
+
+      {:ok, pid} = start_operator(context, skill: ExceptionSkill)
+      {:ok, notifications} = Operator.run(pid, %{}, [])
+
+      assert is_list(notifications)
+    end
+  end
+end

--- a/test/support/exception_test_helper.ex
+++ b/test/support/exception_test_helper.ex
@@ -1,0 +1,30 @@
+defmodule Beamlens.ExceptionTestHelper do
+  @moduledoc false
+
+  alias Beamlens.Skill.Exception.ExceptionStore
+
+  def build_event(opts) do
+    %Tower.Event{
+      id: Keyword.get(opts, :id, UUIDv7.generate()),
+      datetime: Keyword.get(opts, :datetime, DateTime.utc_now()),
+      level: Keyword.get(opts, :level, :error),
+      kind: Keyword.get(opts, :kind, :error),
+      reason: Keyword.get(opts, :reason, %ArgumentError{message: "test error"}),
+      stacktrace: Keyword.get(opts, :stacktrace, default_stacktrace()),
+      log_event: nil,
+      plug_conn: nil,
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  def inject_exception(reason, opts \\ []) do
+    event = build_event(Keyword.put(opts, :reason, reason))
+    GenServer.cast(ExceptionStore, {:exception_event, event})
+    ExceptionStore.flush()
+    event
+  end
+
+  defp default_stacktrace do
+    [{TestModule, :test_fn, 1, [file: ~c"test.ex", line: 1]}]
+  end
+end


### PR DESCRIPTION
## Summary

- Fix Exception skill snapshot data to serialize correctly to JSON by converting `top_types` tuples to maps with `:type` and `:count` keys
- Update `snapshot/0` documentation to describe the return structure
- Extract shared test helpers (`build_event/1`, `inject_exception/2`) into `Beamlens.ExceptionTestHelper`

## Test plan

- [x] Unit tests pass (51 tests)
- [x] Integration tests pass (4 tests)
- [x] Compile with no warnings
- [x] Format check passes