### PR TITLE
Add message queue overload detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Binary memory leak detection callbacks in Beam skill (`beam_binary_leak`, `beam_binary_top_memory`)
+- Message queue overload detection: `beam_queue_processes/1`, `beam_queue_growth/2`, `beam_queue_stats/0`
 - Operators and Coordinator are now always-running supervised processes
 - New `Operator.run_async/3` for running analysis in the background with progress notifications
 - Multiple analysis requests to the same operator are queued and processed in order


### PR DESCRIPTION
Implements three new Beam skill callbacks for detecting message queue overload before it causes OOM crashes:

- beam_queue_processes/1: Returns all processes with queue size > threshold
- beam_queue_growth/2: Tracks fastest-growing queues over time interval
- beam_queue_stats/0: Aggregate queue health metrics

Addresses issue #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)