### PR TITLE
Add memory allocator monitoring for fragmentation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Memory allocator monitoring in Allocator skill: `allocator_summary`, `allocator_by_type`, `allocator_fragmentation`, `allocator_problematic`
+- Allocator metrics: carrier utilization, block efficiency, fragmentation detection for long-running nodes
 - Inet port monitoring callbacks in Ports skill: `ports_list_inet`, `ports_top_by_buffer`, `ports_inet_stats`
 - Socket state tracking for TCP/UDP/SCTP ports with local/remote addresses
 - Buffer size monitoring for detecting backpressure and connection issues

--- a/lib/beamlens/skill/allocator.ex
+++ b/lib/beamlens/skill/allocator.ex
@@ -1,0 +1,336 @@
+defmodule Beamlens.Skill.Allocator do
+  @moduledoc """
+  Memory allocator metrics skill.
+
+  Provides callback functions for monitoring VM memory allocator fragmentation
+  and carrier utilization. Detects memory fragmentation issues in long-running
+  nodes where allocated memory exceeds actual usage.
+
+  ## Memory Fragmentation
+
+  Long-running BEAM nodes can experience allocator fragmentation where:
+  - Memory allocated during peak load is never fully returned to the OS
+  - OS reports much higher memory usage than erlang:memory() shows
+  - VM allocators (binary_alloc, eheap_alloc, ets_alloc, etc.) fragment carriers
+
+  This skill detects such issues by monitoring allocator block and carrier metrics.
+
+  All functions are read-only with zero side effects.
+  """
+
+  @behaviour Beamlens.Skill
+
+  @allocators [
+    :binary_alloc,
+    :eheap_alloc,
+    :ets_alloc,
+    :fix_alloc,
+    :literal_alloc,
+    :temp_alloc,
+    :sl_alloc,
+    :std_alloc,
+    :ll_alloc,
+    :driver_alloc
+  ]
+
+  @impl true
+  def title, do: "Memory Allocators"
+
+  @impl true
+  def description,
+    do: "VM allocator fragmentation: carrier utilization, block efficiency"
+
+  @impl true
+  def system_prompt do
+    """
+    You are a memory allocator monitor. You track VM-level allocator metrics
+    to detect memory fragmentation in long-running nodes.
+
+    ## Your Domain
+    - Allocator carriers and blocks across all VM allocators
+    - Block vs carrier size ratios (fragmentation indicators)
+    - Memory usage efficiency at the allocator level
+
+    ## What to Watch For
+    - Low block/carrier ratio: High fragmentation, carriers underutilized
+    - Many carriers with small blocks: Memory fragmentation
+    - binary_alloc issues: Binary fragmentation after traffic spikes
+    - eheap_alloc issues: Process heap fragmentation
+    - ets_alloc issues: ETS table fragmentation
+
+    ## Fragmentation Detection
+    - Usage ratio < 0.5 (50%): Moderate fragmentation
+    - Usage ratio < 0.3 (30%): Severe fragmentation, investigate
+    - Compare block size vs carrier size to detect waste
+    - Multiple allocators with low ratios: System-wide fragmentation
+
+    ## Remediation
+    - Restart node during maintenance window (returns memory to OS)
+    - Trigger process hibernation to compact heaps
+    - Reduce peak load to lower carrier retention
+    """
+  end
+
+  @impl true
+  def snapshot do
+    allocators = allocator_summary()
+
+    %{
+      allocator_count: length(allocators),
+      total_carriers: Enum.reduce(allocators, 0, fn a, sum -> sum + a.carriers end),
+      fragmented_allocators: Enum.count(allocators, fn a -> a.usage_ratio < 0.5 end),
+      worst_usage_ratio:
+        Enum.min_by(allocators, fn a -> a.usage_ratio end, fn -> %{usage_ratio: 1.0} end).usage_ratio
+    }
+  end
+
+  @impl true
+  def callbacks do
+    %{
+      "allocator_summary" => &allocator_summary/0,
+      "allocator_by_type" => &allocator_by_type/1,
+      "allocator_fragmentation" => &allocator_fragmentation/0,
+      "allocator_problematic" => &allocator_problematic/0
+    }
+  end
+
+  @impl true
+  def callback_docs do
+    """
+    ### allocator_summary()
+    Summary of all allocators with name, carriers, blocks, usage_ratio
+
+    ### allocator_by_type(allocator_name)
+    Detailed metrics for specific allocator: binary_alloc, eheap_alloc, ets_alloc, etc.
+    Returns carriers, blocks, block_size_mb, carrier_size_mb, usage_ratio
+
+    ### allocator_fragmentation()
+    Current vs maximum fragmentation metrics across all allocators
+
+    ### allocator_problematic()
+    Allocators with usage_ratio < 0.5 (potential fragmentation issues)
+    """
+  end
+
+  @doc """
+  Summary metrics for all VM allocators.
+
+  Returns list of maps with allocator name, carriers, blocks,
+  block size, carrier size, and usage ratio (blocks/carriers).
+  """
+  def allocator_summary do
+    @allocators
+    |> Enum.map(&allocator_info/1)
+    |> Enum.filter(fn
+      nil -> false
+      _ -> true
+    end)
+    |> Enum.map(fn {name, instances} ->
+      metrics = aggregate_instances(instances)
+
+      %{
+        name: name,
+        carriers: metrics.carriers,
+        blocks: metrics.blocks,
+        block_size_mb: bytes_to_mb(metrics.blocks_size),
+        carrier_size_mb: bytes_to_mb(metrics.carriers_size),
+        usage_ratio: Float.round(metrics.usage_ratio, 3)
+      }
+    end)
+  end
+
+  @doc """
+  Detailed metrics for a specific allocator type.
+
+  Returns map with carriers, blocks, block_size_mb, carrier_size_mb,
+  and usage_ratio. Returns nil if allocator not found or unavailable.
+  """
+  def allocator_by_type(allocator_name) when allocator_name in @allocators do
+    case safe_allocator_info(allocator_name) do
+      nil ->
+        nil
+
+      {^allocator_name, instances} when is_list(instances) ->
+        metrics = aggregate_instances(instances)
+
+        %{
+          name: allocator_name,
+          carriers: metrics.carriers,
+          blocks: metrics.blocks,
+          block_size_mb: bytes_to_mb(metrics.blocks_size),
+          carrier_size_mb: bytes_to_mb(metrics.carriers_size),
+          usage_ratio: Float.round(metrics.usage_ratio, 3),
+          mseg_carriers: metrics.mseg_carriers,
+          sys_alloc_carriers: metrics.sys_alloc_carriers
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  def allocator_by_type(_allocator_name), do: nil
+
+  @doc """
+  Fragmentation metrics comparing current vs worst-case usage.
+
+  Returns map with average_usage_ratio, worst_allocator (name),
+  worst_usage_ratio, and fragmentation_score.
+  """
+  def allocator_fragmentation do
+    allocators = allocator_summary()
+
+    if allocators == [] do
+      %{
+        average_usage_ratio: 1.0,
+        worst_allocator: nil,
+        worst_usage_ratio: 1.0,
+        fragmentation_score: 0.0
+      }
+    else
+      worst = Enum.min_by(allocators, fn a -> a.usage_ratio end)
+
+      avg_ratio =
+        Enum.reduce(allocators, 0.0, fn a, sum -> sum + a.usage_ratio end) / length(allocators)
+
+      %{
+        average_usage_ratio: Float.round(avg_ratio, 3),
+        worst_allocator: worst.name,
+        worst_usage_ratio: worst.usage_ratio,
+        fragmentation_score: Float.round(1.0 - avg_ratio, 3)
+      }
+    end
+  end
+
+  @doc """
+  Identifies allocators with potential fragmentation issues.
+
+  Returns allocators with usage_ratio < 0.5 (less than 50% carrier utilization).
+  These may indicate memory fragmentation where allocated carriers are
+  underutilized.
+  """
+  def allocator_problematic do
+    allocator_summary()
+    |> Enum.filter(fn a -> a.usage_ratio < 0.5 end)
+    |> Enum.sort_by(fn a -> a.usage_ratio end)
+  end
+
+  defp safe_allocator_info(allocator_name) do
+    case :erlang.system_info({:allocator, allocator_name}) do
+      {:error, _} -> nil
+      instances when is_list(instances) -> {allocator_name, instances}
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp allocator_info(allocator_name) do
+    safe_allocator_info(allocator_name)
+  end
+
+  defp aggregate_instances(instances) when is_list(instances) do
+    Enum.reduce(
+      instances,
+      %{
+        carriers: 0,
+        blocks: 0,
+        blocks_size: 0,
+        carriers_size: 0,
+        mseg_carriers: 0,
+        sys_alloc_carriers: 0
+      },
+      fn {:instance, _instance_num, instance_data}, acc ->
+        mbcs = Keyword.get(instance_data, :mbcs, [])
+        sbcs = Keyword.get(instance_data, :sbcs, [])
+
+        acc
+        |> Map.update!(:carriers, &(&1 + aggregate_carriers(mbcs, sbcs)))
+        |> Map.update!(:blocks, &(&1 + aggregate_blocks(mbcs, sbcs)))
+        |> Map.update!(:blocks_size, &(&1 + aggregate_blocks_size(mbcs, sbcs)))
+        |> Map.update!(:carriers_size, &(&1 + aggregate_carriers_size(mbcs, sbcs)))
+        |> Map.update!(:mseg_carriers, &(&1 + Keyword.get(mbcs, :mseg_alloc_carriers, 0)))
+        |> Map.update!(:mseg_carriers, &(&1 + Keyword.get(sbcs, :mseg_alloc_carriers, 0)))
+        |> Map.update!(:sys_alloc_carriers, &(&1 + Keyword.get(mbcs, :sys_alloc_carriers, 0)))
+        |> Map.update!(:sys_alloc_carriers, &(&1 + Keyword.get(sbcs, :sys_alloc_carriers, 0)))
+      end
+    )
+    |> calculate_usage_ratio()
+  end
+
+  defp aggregate_carriers(mbcs, sbcs) do
+    mbcs_carriers = extract_carriers_count(mbcs)
+    sbcs_carriers = extract_carriers_count(sbcs)
+    mbcs_carriers + sbcs_carriers
+  end
+
+  defp extract_carriers_count(list) do
+    case List.keyfind(list, :carriers, 0) do
+      {:carriers, count, _, _} when is_integer(count) -> count
+      {:carriers, _current, _max, _selected} -> 1
+      _ -> 0
+    end
+  end
+
+  defp aggregate_blocks(mbcs, sbcs) do
+    mbcs_blocks = extract_blocks_count(mbcs)
+    sbcs_blocks = extract_blocks_count(sbcs)
+    mbcs_blocks + sbcs_blocks
+  end
+
+  defp extract_blocks_count(list) do
+    blocks_list = List.keyfind(list, :blocks, 0)
+    sum_blocks_from_list(blocks_list)
+  end
+
+  defp sum_blocks_from_list({:blocks, blocks_list}) when is_list(blocks_list) do
+    Enum.reduce(blocks_list, 0, fn {_alloc_type, counts}, acc ->
+      acc + extract_count_from_tuple(counts)
+    end)
+  end
+
+  defp sum_blocks_from_list(_), do: 0
+
+  defp extract_count_from_tuple({count, _, _, _}) when is_integer(count), do: count
+  defp extract_count_from_tuple({count, _, _}) when is_integer(count), do: count
+  defp extract_count_from_tuple(_), do: 0
+
+  defp aggregate_blocks_size(mbcs, sbcs) do
+    mbcs_size = extract_blocks_size(mbcs)
+    sbcs_size = extract_blocks_size(sbcs)
+    mbcs_size + sbcs_size
+  end
+
+  defp extract_blocks_size(list) do
+    case List.keyfind(list, :blocks_size, 0) do
+      {:blocks_size, size} when is_integer(size) -> size
+      _ -> 0
+    end
+  end
+
+  defp aggregate_carriers_size(mbcs, sbcs) do
+    mbcs_size = extract_carriers_size(mbcs)
+    sbcs_size = extract_carriers_size(sbcs)
+    mbcs_size + sbcs_size
+  end
+
+  defp extract_carriers_size(list) do
+    case List.keyfind(list, :carriers_size, 0) do
+      {:carriers_size, size} when is_integer(size) -> size
+      _ -> 0
+    end
+  end
+
+  defp calculate_usage_ratio(metrics) do
+    usage_ratio =
+      if metrics.carriers_size > 0 do
+        metrics.blocks_size / metrics.carriers_size
+      else
+        1.0
+      end
+
+    Map.put(metrics, :usage_ratio, usage_ratio)
+  end
+
+  defp bytes_to_mb(bytes), do: Float.round(bytes / 1_048_576, 2)
+end

--- a/test/beamlens/skill/allocator_test.exs
+++ b/test/beamlens/skill/allocator_test.exs
@@ -1,0 +1,175 @@
+defmodule Beamlens.Skill.AllocatorTest do
+  use ExUnit.Case
+
+  alias Beamlens.Skill.Allocator
+
+  describe "allocator_summary/0" do
+    test "returns list of allocators with metrics" do
+      summary = Allocator.allocator_summary()
+
+      assert is_list(summary)
+      refute summary == []
+
+      first = hd(summary)
+
+      assert Map.has_key?(first, :name)
+      assert Map.has_key?(first, :carriers)
+      assert Map.has_key?(first, :blocks)
+      assert Map.has_key?(first, :block_size_mb)
+      assert Map.has_key?(first, :carrier_size_mb)
+      assert Map.has_key?(first, :usage_ratio)
+    end
+
+    test "allocator names are valid VM allocators" do
+      summary = Allocator.allocator_summary()
+
+      valid_allocators = [
+        :binary_alloc,
+        :eheap_alloc,
+        :ets_alloc,
+        :fix_alloc,
+        :literal_alloc,
+        :temp_alloc,
+        :sl_alloc,
+        :std_alloc,
+        :ll_alloc,
+        :driver_alloc
+      ]
+
+      Enum.each(summary, fn allocator ->
+        assert allocator.name in valid_allocators
+      end)
+    end
+
+    test "usage ratio is between 0 and 1" do
+      summary = Allocator.allocator_summary()
+
+      Enum.each(summary, fn allocator ->
+        assert allocator.usage_ratio >= 0.0
+        assert allocator.usage_ratio <= 1.0
+      end)
+    end
+  end
+
+  describe "allocator_by_type/1" do
+    test "returns detailed metrics for binary_alloc" do
+      result = Allocator.allocator_by_type(:binary_alloc)
+
+      refute result == nil
+
+      assert result.name == :binary_alloc
+      assert is_integer(result.carriers)
+      assert is_integer(result.blocks)
+      assert result.carrier_size_mb >= 0
+      assert result.block_size_mb >= 0
+      assert result.usage_ratio >= 0.0
+      assert result.usage_ratio <= 1.0
+    end
+
+    test "returns detailed metrics for eheap_alloc" do
+      result = Allocator.allocator_by_type(:eheap_alloc)
+
+      refute result == nil
+
+      assert result.name == :eheap_alloc
+      assert is_integer(result.carriers)
+      assert is_integer(result.blocks)
+      assert is_integer(result.mseg_carriers)
+      assert is_integer(result.sys_alloc_carriers)
+    end
+
+    test "returns detailed metrics for ets_alloc" do
+      result = Allocator.allocator_by_type(:ets_alloc)
+
+      refute result == nil
+
+      assert result.name == :ets_alloc
+      assert is_map(result)
+    end
+
+    test "returns nil for invalid allocator" do
+      result = Allocator.allocator_by_type(:invalid_alloc)
+
+      assert result == nil
+    end
+  end
+
+  describe "allocator_fragmentation/0" do
+    test "returns fragmentation metrics" do
+      result = Allocator.allocator_fragmentation()
+
+      assert Map.has_key?(result, :average_usage_ratio)
+      assert Map.has_key?(result, :worst_allocator)
+      assert Map.has_key?(result, :worst_usage_ratio)
+      assert Map.has_key?(result, :fragmentation_score)
+
+      assert result.average_usage_ratio >= 0.0
+      assert result.average_usage_ratio <= 1.0
+      assert result.worst_usage_ratio >= 0.0
+      assert result.worst_usage_ratio <= 1.0
+      assert result.fragmentation_score >= 0.0
+      assert result.fragmentation_score <= 1.0
+    end
+
+    test "fragmentation score is inverse of average usage ratio" do
+      result = Allocator.allocator_fragmentation()
+
+      expected = 1.0 - result.average_usage_ratio
+
+      assert_in_delta result.fragmentation_score, expected, 0.001
+    end
+  end
+
+  describe "allocator_problematic/0" do
+    test "returns list of allocators with low usage ratio" do
+      result = Allocator.allocator_problematic()
+
+      assert is_list(result)
+
+      Enum.each(result, fn allocator ->
+        assert allocator.usage_ratio < 0.5
+      end)
+    end
+
+    test "returns allocators sorted by usage ratio ascending" do
+      result = Allocator.allocator_problematic()
+
+      if length(result) > 1 do
+        sorted = result |> Enum.map(fn a -> a.usage_ratio end) |> Enum.sort()
+        actual = result |> Enum.map(fn a -> a.usage_ratio end)
+
+        assert actual == sorted
+      end
+    end
+
+    test "may return empty list if no fragmentation detected" do
+      result = Allocator.allocator_problematic()
+
+      assert is_list(result)
+    end
+  end
+
+  describe "snapshot/0" do
+    test "returns aggregate metrics" do
+      snapshot = Allocator.snapshot()
+
+      assert Map.has_key?(snapshot, :allocator_count)
+      assert Map.has_key?(snapshot, :total_carriers)
+      assert Map.has_key?(snapshot, :fragmented_allocators)
+      assert Map.has_key?(snapshot, :worst_usage_ratio)
+
+      assert is_integer(snapshot.allocator_count)
+      assert is_integer(snapshot.total_carriers)
+      assert is_integer(snapshot.fragmented_allocators)
+      assert snapshot.worst_usage_ratio >= 0.0
+      assert snapshot.worst_usage_ratio <= 1.0
+    end
+
+    test "fragmented_allocators count matches allocator_problematic" do
+      snapshot = Allocator.snapshot()
+      problematic = Allocator.allocator_problematic()
+
+      assert snapshot.fragmented_allocators == length(problematic)
+    end
+  end
+end


### PR DESCRIPTION
Implements Issue #11: Memory Fragmentation Detection

Adds Allocator skill with callbacks for monitoring VM memory allocator metrics to detect fragmentation in long-running nodes.

Features:
- allocator_summary: Overview of all allocators with carriers, blocks, usage ratios
- allocator_by_type: Detailed metrics for specific allocators (binary_alloc, eheap_alloc, etc.)
- allocator_fragmentation: Aggregate metrics identifying worst-case fragmentation
- allocator_problematic: Lists allocators with <50% carrier utilization

Zero production impact: All operations read-only using erlang:system_info

Tests: 14 tests covering all callback functionality