### PR TITLE
Include thought field in Coordinator think telemetry

### DIFF
--- a/lib/beamlens/coordinator.ex
+++ b/lib/beamlens/coordinator.ex
@@ -605,7 +605,7 @@ defmodule Beamlens.Coordinator do
   end
 
   defp handle_action(%Think{thought: thought}, state, trace_id) do
-    emit_telemetry(:think, state, %{trace_id: trace_id})
+    emit_telemetry(:think, state, %{trace_id: trace_id, thought: thought})
 
     result = %{thought: thought, recorded: true}
     new_context = Utils.add_result(state.context, result)

--- a/lib/beamlens/telemetry.ex
+++ b/lib/beamlens/telemetry.ex
@@ -179,7 +179,7 @@ defmodule Beamlens.Telemetry do
 
   * `[:beamlens, :coordinator, :think]` - Coordinator recorded a thought
     - Measurements: `%{system_time: integer}`
-    - Metadata: `%{trace_id: String.t()}`
+    - Metadata: `%{trace_id: String.t(), thought: String.t()}`
 
   * `[:beamlens, :coordinator, :operator_notification_received]` - Notification received from running operator
     - Measurements: `%{system_time: integer}`


### PR DESCRIPTION
## Summary
- Add `thought` field to Coordinator's think telemetry metadata for consistency with Operator
- Update telemetry documentation to reflect the new field

## Test plan
- [x] All existing tests pass (773 tests, 0 failures)