### PR TITLE
Include status field in Coordinator get_notifications telemetry

### DIFF
--- a/lib/beamlens/coordinator.ex
+++ b/lib/beamlens/coordinator.ex
@@ -470,7 +470,11 @@ defmodule Beamlens.Coordinator do
         NotificationView.from_entry(id, entry)
       end)
 
-    emit_telemetry(:get_notifications, state, %{trace_id: trace_id, count: length(result)})
+    emit_telemetry(:get_notifications, state, %{
+      trace_id: trace_id,
+      status: status,
+      count: length(result)
+    })
 
     new_context = Utils.add_result(state.context, result)
 

--- a/test/integration/coordinator_operator_test.exs
+++ b/test/integration/coordinator_operator_test.exs
@@ -120,10 +120,12 @@ defmodule Beamlens.Integration.CoordinatorOperatorTest do
       assert is_map(result)
       assert is_list(result.insights)
 
-      assert_receive {:telemetry, [:beamlens, :coordinator, :get_notifications], %{count: count}},
+      assert_receive {:telemetry, [:beamlens, :coordinator, :get_notifications],
+                      %{count: count, status: status}},
                      0
 
       assert count >= 0
+      assert status in [:unread, :acknowledged, :resolved, :all, nil]
       assert_receive {:telemetry, [:beamlens, :coordinator, :done], _}, 0
     end
   end


### PR DESCRIPTION
## Summary

- Add missing `status` field to the `[:beamlens, :coordinator, :get_notifications]` telemetry event metadata
- Update integration test to verify the status field is present

## Context

The documentation in `lib/beamlens/telemetry.ex:138` specifies metadata should be:
```
%{trace_id: String.t(), status: atom(), count: integer}
```

But the actual emission at `lib/beamlens/coordinator.ex:473` was only:
```
%{trace_id: trace_id, count: length(result)}
```

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test test/beamlens/coordinator_test.exs` passes (84 tests)