### PR TITLE
Catch operator GenServer exits to prevent coordinator crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Coordinator no longer crashes when an operator GenServer times out during `message_operator` or `get_operator_statuses` actions
+- `list_operators/0` and `operator_status/1` no longer crash when an operator is unresponsive
 - Coordinator no longer gets stuck in `:running` when the LLM calls `done()` with unread notifications remaining
 - `mix compile` no longer fails in prod when `igniter` is not a dependency
 


### PR DESCRIPTION
Closes #52

## Summary

- Wrap `Operator.message/2` and `Operator.status/1` calls in `try/catch` blocks across coordinator and operator supervisor so that GenServer timeouts or process exits return error tuples instead of crashing the caller
- Coordinator `message_operator` action now returns `"operator timed out"` error to LLM context instead of terminating
- Coordinator `get_operator_statuses` action reports unresponsive operators as dead
- `list_operators/0` returns a `:busy` status for unresponsive operators
- `operator_status/1` returns `{:error, :timeout}` for unresponsive operators

## Test plan

- [x] New coordinator tests: operator exit during `message_operator` and `get_operator_statuses` — coordinator survives and returns expected error context
- [x] New supervisor tests: `list_operators/0` returns busy status and `operator_status/1` returns `{:error, :timeout}` when operator is suspended
- [x] Full test suite passes (812 tests, 0 failures)
- [x] Clean compilation with no warnings