### PR TITLE
Add @derive Jason.Encoder to CompletionResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `CompletionResult` now derives `Jason.Encoder` so coordinator results can be JSON-encoded
 - Coordinator no longer crashes when the LLM returns an invalid or unparseable tool selection
 
 ## [0.3.1] - 2026-02-09

--- a/lib/beamlens/operator/completion_result.ex
+++ b/lib/beamlens/operator/completion_result.ex
@@ -7,6 +7,7 @@ defmodule Beamlens.Operator.CompletionResult do
 
   alias Beamlens.Operator.{Notification, Snapshot}
 
+  @derive Jason.Encoder
   defstruct [:state, :notifications, :snapshots]
 
   @type t :: %__MODULE__{

--- a/test/beamlens/operator_test.exs
+++ b/test/beamlens/operator_test.exs
@@ -573,6 +573,21 @@ defmodule Beamlens.OperatorTest do
     end
   end
 
+  describe "CompletionResult JSON encoding" do
+    alias Beamlens.Operator.CompletionResult
+
+    test "encodes to JSON" do
+      result = %CompletionResult{
+        state: :healthy,
+        notifications: [],
+        snapshots: []
+      }
+
+      assert {:ok, json} = Jason.encode(result)
+      assert %{"state" => "healthy"} = Jason.decode!(json)
+    end
+  end
+
   describe "puck_client override" do
     test "uses provided puck_client for loop responses" do
       responses = [


### PR DESCRIPTION
## Summary

- Adds missing `@derive Jason.Encoder` to `Beamlens.Operator.CompletionResult`, fixing `Protocol.UndefinedError` when JSON-encoding coordinator results
- Adds test verifying `CompletionResult` encodes to JSON
- Updates CHANGELOG

Closes #55