### PR TITLE
Add Strategy behaviour for pluggable coordinator execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Pluggable coordinator strategy via `Beamlens.Coordinator.Strategy` behaviour — pass `:strategy` to `start_link/1` or `run/2` to use a custom execution strategy instead of the default `AgentLoop`
 - Coordinator enforces a server-side deadline to stop runaway investigations when the caller times out
 - Coordinator monitors the caller process and cancels if the caller exits
 - `Beamlens.Coordinator.cancel/1` to gracefully halt a running investigation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,17 @@ State transitions are driven by the LLM via the `set_state` tool.
 
 ## Coordinator
 
-The Coordinator is a GenServer that correlates operator notifications into unified insights. When you call `Beamlens.Coordinator.run/2`, it spawns operators, collects their notifications, and runs an LLM-driven analysis to produce insights.
+The Coordinator is a GenServer that correlates operator notifications into unified insights. When you call `Beamlens.Coordinator.run/2`, the configured strategy drives LLM-based analysis, invoking operators as needed and correlating their notifications into insights.
+
+### Execution Strategy
+
+The Coordinator delegates tool dispatch to a pluggable strategy module implementing the `Beamlens.Coordinator.Strategy` behaviour. The default strategy is `Beamlens.Coordinator.Strategy.AgentLoop`, which runs an iterative agentic loop with tool-calling.
+
+The strategy owns action handling — it decides what to do with each tool the LLM selects. The coordinator retains GenServer infrastructure (queueing, operator lifecycle, deadlines, caller monitoring).
+
+```elixir
+Beamlens.Coordinator.run(%{reason: "health check"}, strategy: MyCustomStrategy)
+```
 
 ### Notification States
 

--- a/lib/beamlens/coordinator/strategy.ex
+++ b/lib/beamlens/coordinator/strategy.ex
@@ -21,18 +21,9 @@ defmodule Beamlens.Coordinator.Strategy do
 
         @impl true
         def handle_action(%MyTool{} = action, state, trace_id) do
-          # custom handling
           {:noreply, state, {:continue, :loop}}
         end
       end
-
-  ## Auto-routing
-
-  Strategies can optionally implement `handles?/1` for auto-routing:
-
-      @impl true
-      def handles?(%{reason: "pipeline:" <> _}), do: true
-      def handles?(_context), do: false
 
   """
 
@@ -40,8 +31,4 @@ defmodule Beamlens.Coordinator.Strategy do
               {:noreply, struct()}
               | {:noreply, struct(), {:continue, :loop}}
               | {:finish, struct()}
-
-  @callback handles?(context :: map()) :: boolean()
-
-  @optional_callbacks [handles?: 1]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -155,7 +155,9 @@ defmodule Beamlens.MixProject do
           Beamlens.Coordinator,
           Beamlens.Coordinator.Insight,
           Beamlens.Coordinator.Tools,
-          Beamlens.Coordinator.Status
+          Beamlens.Coordinator.Status,
+          Beamlens.Coordinator.Strategy,
+          Beamlens.Coordinator.Strategy.AgentLoop
         ],
         Skill: [
           Beamlens.Skill,


### PR DESCRIPTION
## Summary

- Introduces `Beamlens.Coordinator.Strategy` behaviour so the coordinator delegates tool dispatch to pluggable execution strategies
- Extracts all 10 `handle_action/3` clauses into `Beamlens.Coordinator.Strategy.AgentLoop` (the default strategy)
- Coordinator retains GenServer infrastructure (queueing, operator lifecycle, deadlines, caller monitoring); strategy owns action handling
- Pass `:strategy` to `start_link/1` or `run/2` to use a custom strategy; per-invocation overrides are supported including for queued invocations

Closes #59

## Test plan

- [x] All 113 coordinator tests pass (including 8 new strategy-specific tests)
- [x] Full suite: 842 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] 11-agent pre-release review passes with no blocking issues