### PR TITLE
Add Pipeline strategy for classify-gather-synthesize coordinator flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Pluggable coordinator strategy via `Beamlens.Coordinator.Strategy` behaviour — pass `:strategy` to `start_link/1` or `run/2` to use a custom execution strategy instead of the default `AgentLoop`
+- `Pipeline` strategy for faster, cheaper investigations — classifies the query, gathers data in parallel, and synthesizes a single answer with fewer LLM calls
+- Custom strategies can define an optional `continue_loop/2` callback to control the full execution flow instead of processing one tool action at a time
+- Telemetry events for Pipeline strategy stages: `pipeline_classify_start`, `pipeline_classify_complete`, `pipeline_synthesize_start`, `pipeline_synthesize_complete`
 - Coordinator enforces a server-side deadline to stop runaway investigations when the caller times out
 - Coordinator monitors the caller process and cancels if the caller exits
 - `Beamlens.Coordinator.cancel/1` to gracefully halt a running investigation

--- a/lib/beamlens/coordinator.ex
+++ b/lib/beamlens/coordinator.ex
@@ -330,7 +330,8 @@ defmodule Beamlens.Coordinator do
       iteration: state.iteration
     })
 
-    if function_exported?(state.strategy, :continue_loop, 2) do
+    if Code.ensure_loaded?(state.strategy) and
+         function_exported?(state.strategy, :continue_loop, 2) do
       state.strategy.continue_loop(state, trace_id)
     else
       default_loop(state, trace_id)

--- a/lib/beamlens/coordinator/strategy/pipeline.ex
+++ b/lib/beamlens/coordinator/strategy/pipeline.ex
@@ -1,0 +1,200 @@
+defmodule Beamlens.Coordinator.Strategy.Pipeline do
+  @moduledoc """
+  Decomposed classify-gather-synthesize strategy for the coordinator.
+
+  Replaces the iterative agent loop with three focused stages:
+
+    1. **Classify** — Single LLM call to determine intent and select skills
+    2. **Gather** — Invoke operators with focused context, await completion
+    3. **Synthesize** — Single LLM call to produce a human-readable answer
+
+  This strategy uses fewer, more focused LLM calls compared to `AgentLoop`,
+  making it faster and cheaper for straightforward queries.
+
+      Beamlens.Coordinator.run(%{reason: "What OS is running?"}, strategy: Pipeline)
+
+  """
+
+  @behaviour Beamlens.Coordinator.Strategy
+
+  alias Beamlens.Coordinator
+  alias Beamlens.Coordinator.{Insight, NotificationView}
+  alias Beamlens.Coordinator.Strategy.Pipeline.Tools, as: PipelineTools
+  alias Beamlens.Coordinator.Strategy.Pipeline.Tools.{ClassifyResult, SynthesizeResult}
+  alias Beamlens.LLM.Utils
+
+  @gather_poll_ms 500
+
+  @impl true
+  def continue_loop(%{strategy_state: nil} = state, trace_id) do
+    Coordinator.emit_telemetry(:pipeline_classify_start, state, %{trace_id: trace_id})
+
+    query = extract_query(state.context)
+    available_skills = Coordinator.build_operator_descriptions(state.skills)
+
+    client =
+      build_pipeline_client(
+        "PipelineClassify",
+        %{query: query, available_skills: available_skills},
+        state.client_registry
+      )
+
+    task =
+      Beamlens.LLMTask.async(fn ->
+        Puck.call(client, query, Puck.Context.new(),
+          output_schema: PipelineTools.classify_schema()
+        )
+      end)
+
+    {:noreply,
+     %{state | strategy_state: :classifying, pending_task: task, pending_trace_id: trace_id}}
+  end
+
+  def continue_loop(%{strategy_state: :gathering} = state, trace_id) do
+    if map_size(state.running_operators) == 0 do
+      start_synthesize(state, trace_id)
+    else
+      Process.send_after(self(), :continue_after_wait, @gather_poll_ms)
+      {:noreply, %{state | pending_trace_id: nil}}
+    end
+  end
+
+  @impl true
+  def handle_action(%ClassifyResult{} = result, state, trace_id) do
+    Coordinator.emit_telemetry(:pipeline_classify_complete, state, %{
+      trace_id: trace_id,
+      intent: result.intent,
+      skills: result.skills
+    })
+
+    new_running =
+      Enum.reduce(result.skills, state.running_operators, fn skill, acc ->
+        Coordinator.start_operator(skill, result.operator_context, acc)
+      end)
+
+    started_count = map_size(new_running) - map_size(state.running_operators)
+
+    new_state = %{
+      state
+      | running_operators: new_running,
+        strategy_state: :gathering,
+        iteration: state.iteration + 1,
+        pending_trace_id: nil
+    }
+
+    if started_count == 0 do
+      {:noreply, new_state, {:continue, :loop}}
+    else
+      Process.send_after(self(), :continue_after_wait, @gather_poll_ms)
+      {:noreply, new_state}
+    end
+  end
+
+  @impl true
+  def handle_action(%SynthesizeResult{answer: answer}, state, trace_id) do
+    Coordinator.emit_telemetry(:pipeline_synthesize_complete, state, %{
+      trace_id: trace_id
+    })
+
+    notification_ids = Map.keys(state.notifications)
+
+    insights =
+      case notification_ids do
+        [] ->
+          state.insights
+
+        [_ | _] ->
+          insight =
+            Insight.new(%{
+              notification_ids: notification_ids,
+              correlation_type: :symptomatic,
+              summary: answer,
+              matched_observations: extract_observations(state.notifications),
+              hypothesis_grounded: false,
+              confidence: :medium
+            })
+
+          [insight | state.insights]
+      end
+
+    new_notifications =
+      Coordinator.update_notifications_status(
+        state.notifications,
+        notification_ids,
+        :resolved
+      )
+
+    new_state = %{
+      state
+      | notifications: new_notifications,
+        insights: insights,
+        strategy_state: :done,
+        iteration: state.iteration + 1,
+        pending_trace_id: nil
+    }
+
+    {:finish, new_state}
+  end
+
+  defp start_synthesize(state, trace_id) do
+    Coordinator.emit_telemetry(:pipeline_synthesize_start, state, %{trace_id: trace_id})
+
+    query = extract_query(state.context)
+    operator_data = build_operator_data(state.notifications)
+
+    client =
+      build_pipeline_client(
+        "PipelineSynthesize",
+        %{query: query, operator_data: operator_data},
+        state.client_registry
+      )
+
+    task =
+      Beamlens.LLMTask.async(fn ->
+        Puck.call(client, query, Puck.Context.new(),
+          output_schema: PipelineTools.synthesize_schema()
+        )
+      end)
+
+    {:noreply,
+     %{state | strategy_state: :synthesizing, pending_task: task, pending_trace_id: trace_id}}
+  end
+
+  defp extract_query(%Puck.Context{messages: []}) do
+    "Analyze the system"
+  end
+
+  defp extract_query(%Puck.Context{messages: [first | _]}) do
+    Utils.extract_text_content(first.content)
+  end
+
+  defp build_operator_data(notifications) do
+    notifications
+    |> Enum.map(fn {id, entry} ->
+      id
+      |> NotificationView.from_entry(entry)
+      |> Map.from_struct()
+      |> Map.take([:id, :operator, :severity, :context, :observation, :detected_at])
+    end)
+    |> Jason.encode!()
+  end
+
+  defp extract_observations(notifications) do
+    notifications
+    |> Map.values()
+    |> Enum.map(fn %{notification: n} -> n.observation end)
+  end
+
+  defp build_pipeline_client(function, args, client_registry) do
+    backend_config =
+      %{
+        function: function,
+        args_format: :raw,
+        args: args,
+        path: Application.app_dir(:beamlens, "priv/baml_src")
+      }
+      |> Utils.maybe_add_client_registry(client_registry)
+
+    Puck.Client.new({Puck.Backends.Baml, backend_config}, hooks: Beamlens.Telemetry.Hooks)
+  end
+end

--- a/lib/beamlens/coordinator/strategy/pipeline/tools.ex
+++ b/lib/beamlens/coordinator/strategy/pipeline/tools.ex
@@ -1,0 +1,42 @@
+defmodule Beamlens.Coordinator.Strategy.Pipeline.Tools do
+  @moduledoc false
+
+  defmodule ClassifyResult do
+    @moduledoc false
+    defstruct [:intent, :skills, :operator_context]
+
+    @type t :: %__MODULE__{
+            intent: :question | :investigation,
+            skills: [String.t()],
+            operator_context: String.t()
+          }
+  end
+
+  defmodule SynthesizeResult do
+    @moduledoc false
+    defstruct [:answer]
+
+    @type t :: %__MODULE__{answer: String.t()}
+  end
+
+  def classify_schema do
+    Zoi.object(%{
+      intent:
+        Zoi.enum(["question", "investigation"])
+        |> Zoi.transform(&atomize_intent/1),
+      skills: Zoi.list(Zoi.string()),
+      operator_context: Zoi.string()
+    })
+    |> Zoi.transform(fn data -> {:ok, struct!(ClassifyResult, data)} end)
+  end
+
+  def synthesize_schema do
+    Zoi.object(%{
+      answer: Zoi.string()
+    })
+    |> Zoi.transform(fn data -> {:ok, struct!(SynthesizeResult, data)} end)
+  end
+
+  defp atomize_intent("question"), do: {:ok, :question}
+  defp atomize_intent("investigation"), do: {:ok, :investigation}
+end

--- a/lib/beamlens/telemetry.ex
+++ b/lib/beamlens/telemetry.ex
@@ -225,6 +225,25 @@ defmodule Beamlens.Telemetry do
     - Measurements: `%{system_time: integer}`
     - Metadata: `%{reason: String.t()}`
 
+  ### Pipeline Strategy Events
+
+  * `[:beamlens, :coordinator, :pipeline_classify_start]` - Pipeline classify stage started
+    - Measurements: `%{system_time: integer}`
+    - Metadata: `%{running: boolean, notification_count: integer, trace_id: String.t()}`
+
+  * `[:beamlens, :coordinator, :pipeline_classify_complete]` - Pipeline classify stage completed
+    - Measurements: `%{system_time: integer}`
+    - Metadata: `%{running: boolean, notification_count: integer, trace_id: String.t(),
+                   intent: atom(), skills: list(String.t())}`
+
+  * `[:beamlens, :coordinator, :pipeline_synthesize_start]` - Pipeline synthesize stage started
+    - Measurements: `%{system_time: integer}`
+    - Metadata: `%{running: boolean, notification_count: integer, trace_id: String.t()}`
+
+  * `[:beamlens, :coordinator, :pipeline_synthesize_complete]` - Pipeline synthesize stage completed
+    - Measurements: `%{system_time: integer}`
+    - Metadata: `%{running: boolean, notification_count: integer, trace_id: String.t()}`
+
   ## Compaction Events
 
   * `[:beamlens, :compaction, :start]` - Context compaction starting
@@ -310,6 +329,10 @@ defmodule Beamlens.Telemetry do
       [:beamlens, :coordinator, :schedule],
       [:beamlens, :coordinator, :schedule_rejected],
       [:beamlens, :coordinator, :scheduled_reinvoke],
+      [:beamlens, :coordinator, :pipeline_classify_start],
+      [:beamlens, :coordinator, :pipeline_classify_complete],
+      [:beamlens, :coordinator, :pipeline_synthesize_start],
+      [:beamlens, :coordinator, :pipeline_synthesize_complete],
       [:beamlens, :compaction, :start],
       [:beamlens, :compaction, :stop]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -157,7 +157,8 @@ defmodule Beamlens.MixProject do
           Beamlens.Coordinator.Tools,
           Beamlens.Coordinator.Status,
           Beamlens.Coordinator.Strategy,
-          Beamlens.Coordinator.Strategy.AgentLoop
+          Beamlens.Coordinator.Strategy.AgentLoop,
+          Beamlens.Coordinator.Strategy.Pipeline
         ],
         Skill: [
           Beamlens.Skill,

--- a/priv/baml_src/pipeline.baml
+++ b/priv/baml_src/pipeline.baml
@@ -1,0 +1,86 @@
+class PipelineClassifyResult {
+  intent "question" | "investigation" @description("question = direct answer needed, investigation = deeper analysis")
+  skills string[] @description("Skill modules to invoke (e.g., [\"Beamlens.Skill.Beam\"])")
+  operator_context string @description("Focused context to pass to operators instead of raw query")
+}
+
+function PipelineClassify(query: string, available_skills: string) -> PipelineClassifyResult {
+  client Default
+  prompt #"
+{{ _.role("system") }}
+You are a query classifier for a BEAM application monitoring system.
+
+Given a user query and available skills, determine:
+1. The intent: "question" for direct questions, "investigation" for deeper analysis
+2. Which skills to invoke to gather the needed data
+3. A focused context string for the operators (more specific than the raw query)
+
+## Available Skills
+
+{{ available_skills }}
+
+## Rules
+- Select only skills relevant to the query
+- The operator_context should be actionable and specific
+- For simple questions, select the minimum skills needed
+
+{{ _.role("user") }}
+{{ query }}
+
+{{ ctx.output_format }}
+"#
+}
+
+class PipelineSynthesizeResult {
+  answer string @description("Human-readable answer to the original question")
+}
+
+function PipelineSynthesize(query: string, operator_data: string) -> PipelineSynthesizeResult {
+  client Default
+  prompt #"
+{{ _.role("system") }}
+You are a response synthesizer for a BEAM application monitoring system.
+
+Given the original user query and data gathered by operators, produce a clear,
+concise answer. Base your answer strictly on the factual data provided.
+Do not speculate beyond what the data shows.
+
+{{ _.role("user") }}
+## Original Question
+{{ query }}
+
+## Operator Data
+{{ operator_data }}
+
+Synthesize a clear answer based on the operator data above.
+
+{{ ctx.output_format }}
+"#
+}
+
+test PipelineClassify_SimpleQuestion {
+  functions [PipelineClassify]
+  args {
+    query "What OS is running?"
+    available_skills "- Beamlens.Skill.Os: Operating system monitoring\n- Beamlens.Skill.Beam: BEAM VM health"
+  }
+  @@assert(selects_os_skill, {{ "Beamlens.Skill.Os" in this.skills }})
+}
+
+test PipelineClassify_BeamQuestion {
+  functions [PipelineClassify]
+  args {
+    query "How much memory is the BEAM using?"
+    available_skills "- Beamlens.Skill.Beam: BEAM VM health: memory, processes, schedulers, atoms\n- Beamlens.Skill.Ets: ETS table monitoring"
+  }
+  @@assert(selects_beam_skill, {{ "Beamlens.Skill.Beam" in this.skills }})
+}
+
+test PipelineSynthesize_SimpleAnswer {
+  functions [PipelineSynthesize]
+  args {
+    query "What OS is running?"
+    operator_data #"[{"operator":"Beamlens.Skill.Os","context":"System running normally","observation":"Operating system is macOS (darwin) on arm64 architecture"}]"#
+  }
+  @@assert(mentions_macos, {{ "macOS" in this.answer or "darwin" in this.answer }})
+}

--- a/test/beamlens/coordinator/strategy/pipeline_test.exs
+++ b/test/beamlens/coordinator/strategy/pipeline_test.exs
@@ -1,0 +1,482 @@
+defmodule Beamlens.Coordinator.Strategy.PipelineTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+
+  alias Beamlens.Coordinator
+  alias Beamlens.Coordinator.Strategy.Pipeline
+  alias Beamlens.Coordinator.Strategy.Pipeline.Tools.{ClassifyResult, SynthesizeResult}
+  alias Beamlens.Operator.Notification
+
+  defp mock_client do
+    Puck.Client.new({Puck.Backends.Mock, error: :test_stop})
+  end
+
+  defp start_pipeline_coordinator(opts \\ []) do
+    Process.flag(:trap_exit, true)
+    name = :"pipeline_#{:erlang.unique_integer([:positive])}"
+
+    opts =
+      opts
+      |> Keyword.put(:name, name)
+      |> Keyword.put_new(:strategy, Pipeline)
+
+    {:ok, pid} = Coordinator.start_link(opts)
+
+    :sys.replace_state(pid, fn state ->
+      %{state | client: mock_client()}
+    end)
+
+    {:ok, pid}
+  end
+
+  defp stop_coordinator(pid) do
+    if Process.alive?(pid) do
+      :sys.replace_state(pid, fn state ->
+        %{state | pending_task: nil}
+      end)
+
+      GenServer.stop(pid, :normal)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp build_test_notification(overrides \\ %{}) do
+    Notification.new(
+      Map.merge(
+        %{
+          operator: :test,
+          anomaly_type: "test_anomaly",
+          severity: :info,
+          context: "Test context",
+          observation: "Test observation",
+          snapshots: []
+        },
+        overrides
+      )
+    )
+  end
+
+  defp completed_task do
+    task = Task.async(fn -> :ok end)
+    Task.await(task)
+    task
+  end
+
+  defp send_action(pid, task, content) do
+    send(pid, {task.ref, {:ok, %{content: content}, Puck.Context.new()}})
+  end
+
+  describe "strategy_state initialization" do
+    test "starts with nil strategy_state" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      state = :sys.get_state(pid)
+      assert state.strategy == Pipeline
+      assert state.strategy_state == nil
+
+      stop_coordinator(pid)
+    end
+  end
+
+  describe "continue_loop/2 — classify stage" do
+    test "sets strategy_state to :classifying and starts a task" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        {ref, :classify_start},
+        [:beamlens, :coordinator, :pipeline_classify_start],
+        fn _event, _measurements, metadata, _ ->
+          send(parent, {:telemetry, :classify_start, metadata})
+        end,
+        nil
+      )
+
+      :sys.replace_state(pid, fn state ->
+        context = Coordinator.build_initial_context(%{reason: "what OS is running?"})
+        %{state | status: :running, context: context}
+      end)
+
+      send(pid, :continue_after_wait)
+
+      assert_receive {:telemetry, :classify_start, _}, 2_000
+
+      state = :sys.get_state(pid)
+      assert state.strategy_state == :classifying
+
+      stop_coordinator(pid)
+      :telemetry.detach({ref, :classify_start})
+    end
+  end
+
+  describe "handle_action — ClassifyResult" do
+    test "transitions to :gathering and increments iteration" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      task = completed_task()
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :classifying,
+            pending_task: task,
+            pending_trace_id: "test-trace"
+        }
+      end)
+
+      classify_result = %ClassifyResult{
+        intent: :question,
+        skills: ["Nonexistent.Skill.Here"],
+        operator_context: "Report the OS"
+      }
+
+      send_action(pid, task, classify_result)
+
+      state = :sys.get_state(pid)
+      assert state.iteration == 1
+
+      stop_coordinator(pid)
+    end
+
+    test "no operators found continues to synthesize stage" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        {ref, :classify_complete},
+        [:beamlens, :coordinator, :pipeline_classify_complete],
+        fn _event, _measurements, metadata, _ ->
+          send(parent, {:telemetry, :classify_complete, metadata})
+        end,
+        nil
+      )
+
+      task = completed_task()
+
+      :sys.replace_state(pid, fn state ->
+        context = Coordinator.build_initial_context(%{reason: "test"})
+
+        %{
+          state
+          | status: :running,
+            strategy_state: :classifying,
+            pending_task: task,
+            pending_trace_id: "test-trace",
+            context: context
+        }
+      end)
+
+      classify_result = %ClassifyResult{
+        intent: :question,
+        skills: ["Nonexistent.Skill"],
+        operator_context: "test"
+      }
+
+      send_action(pid, task, classify_result)
+
+      assert_receive {:telemetry, :classify_complete, _}, 1_000
+
+      state = :sys.get_state(pid)
+      assert map_size(state.running_operators) == 0
+
+      stop_coordinator(pid)
+      :telemetry.detach({ref, :classify_complete})
+    end
+
+    test "emits pipeline_classify_complete telemetry" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        {ref, :classify_complete},
+        [:beamlens, :coordinator, :pipeline_classify_complete],
+        fn _event, _measurements, metadata, _ ->
+          send(parent, {:telemetry, :classify_complete, metadata})
+        end,
+        nil
+      )
+
+      task = completed_task()
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :classifying,
+            pending_task: task,
+            pending_trace_id: "test-trace"
+        }
+      end)
+
+      classify_result = %ClassifyResult{
+        intent: :question,
+        skills: ["Beamlens.Skill.Beam"],
+        operator_context: "Report the OS"
+      }
+
+      send_action(pid, task, classify_result)
+
+      assert_receive {:telemetry, :classify_complete,
+                      %{intent: :question, skills: ["Beamlens.Skill.Beam"]}},
+                     1_000
+
+      stop_coordinator(pid)
+      :telemetry.detach({ref, :classify_complete})
+    end
+  end
+
+  describe "continue_loop/2 — gathering stage" do
+    test "polls when operators still running" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      fake_operator_pid = spawn(fn -> :timer.sleep(:infinity) end)
+      fake_ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :gathering,
+            running_operators: %{
+              fake_operator_pid => %{
+                skill: Beamlens.Skill.Beam,
+                ref: fake_ref,
+                started_at: DateTime.utc_now()
+              }
+            }
+        }
+      end)
+
+      send(pid, :continue_after_wait)
+
+      state = :sys.get_state(pid)
+      assert state.strategy_state == :gathering
+
+      Process.exit(fake_operator_pid, :kill)
+      stop_coordinator(pid)
+    end
+
+    test "transitions to :synthesizing when operators complete" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        {ref, :synthesize_start},
+        [:beamlens, :coordinator, :pipeline_synthesize_start],
+        fn _event, _measurements, metadata, _ ->
+          send(parent, {:telemetry, :synthesize_start, metadata})
+        end,
+        nil
+      )
+
+      notification = build_test_notification()
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :gathering,
+            running_operators: %{},
+            notifications: %{
+              notification.id => %{notification: notification, status: :unread}
+            },
+            context: Coordinator.build_initial_context(%{reason: "test query"})
+        }
+      end)
+
+      send(pid, :continue_after_wait)
+
+      assert_receive {:telemetry, :synthesize_start, _}, 2_000
+
+      state = :sys.get_state(pid)
+      assert state.strategy_state == :synthesizing
+
+      stop_coordinator(pid)
+      :telemetry.detach({ref, :synthesize_start})
+    end
+  end
+
+  describe "handle_action — SynthesizeResult" do
+    test "creates insight from notifications and finishes" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      task = completed_task()
+      notification = build_test_notification()
+
+      caller_ref = make_ref()
+      caller = {self(), caller_ref}
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :synthesizing,
+            pending_task: task,
+            pending_trace_id: "test-trace",
+            caller: caller,
+            notifications: %{
+              notification.id => %{notification: notification, status: :unread}
+            }
+        }
+      end)
+
+      synthesize_result = %SynthesizeResult{answer: "The system is running macOS."}
+      send_action(pid, task, synthesize_result)
+
+      assert_receive {^caller_ref, {:ok, result}}, 1_000
+
+      assert length(result.insights) == 1
+      [insight] = result.insights
+      assert insight.summary == "The system is running macOS."
+      assert notification.id in insight.notification_ids
+
+      stop_coordinator(pid)
+    end
+
+    test "resolves all notifications" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      task = completed_task()
+      n1 = build_test_notification(%{anomaly_type: "type1"})
+      n2 = build_test_notification(%{anomaly_type: "type2"})
+
+      caller_ref = make_ref()
+      caller = {self(), caller_ref}
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :synthesizing,
+            pending_task: task,
+            pending_trace_id: "test-trace",
+            caller: caller,
+            notifications: %{
+              n1.id => %{notification: n1, status: :unread},
+              n2.id => %{notification: n2, status: :unread}
+            }
+        }
+      end)
+
+      synthesize_result = %SynthesizeResult{answer: "Both issues are related."}
+      send_action(pid, task, synthesize_result)
+
+      assert_receive {^caller_ref, {:ok, _result}}, 1_000
+
+      stop_coordinator(pid)
+    end
+
+    test "handles no notifications gracefully" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      task = completed_task()
+
+      caller_ref = make_ref()
+      caller = {self(), caller_ref}
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :synthesizing,
+            pending_task: task,
+            pending_trace_id: "test-trace",
+            caller: caller,
+            notifications: %{}
+        }
+      end)
+
+      synthesize_result = %SynthesizeResult{answer: "No issues found."}
+      send_action(pid, task, synthesize_result)
+
+      assert_receive {^caller_ref, {:ok, result}}, 1_000
+      assert result.insights == []
+
+      stop_coordinator(pid)
+    end
+
+    test "emits pipeline_synthesize_complete telemetry" do
+      {:ok, pid} = start_pipeline_coordinator()
+
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        {ref, :synthesize_complete},
+        [:beamlens, :coordinator, :pipeline_synthesize_complete],
+        fn _event, _measurements, metadata, _ ->
+          send(parent, {:telemetry, :synthesize_complete, metadata})
+        end,
+        nil
+      )
+
+      task = completed_task()
+      caller_ref = make_ref()
+      caller = {self(), caller_ref}
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | status: :running,
+            strategy_state: :synthesizing,
+            pending_task: task,
+            pending_trace_id: "test-trace",
+            caller: caller,
+            notifications: %{}
+        }
+      end)
+
+      synthesize_result = %SynthesizeResult{answer: "All good."}
+      send_action(pid, task, synthesize_result)
+
+      assert_receive {:telemetry, :synthesize_complete, %{trace_id: "test-trace"}}, 1_000
+
+      stop_coordinator(pid)
+      :telemetry.detach({ref, :synthesize_complete})
+    end
+  end
+
+  describe "Pipeline tools schemas" do
+    alias Beamlens.Coordinator.Strategy.Pipeline.Tools, as: PipelineTools
+
+    test "classify_schema parses valid classify result" do
+      input = %{
+        intent: "question",
+        skills: ["Beamlens.Skill.Beam"],
+        operator_context: "Check memory"
+      }
+
+      assert {:ok, %ClassifyResult{intent: :question, skills: ["Beamlens.Skill.Beam"]}} =
+               Zoi.parse(PipelineTools.classify_schema(), input)
+    end
+
+    test "classify_schema parses investigation intent" do
+      input = %{
+        intent: "investigation",
+        skills: ["Beamlens.Skill.Beam", "Beamlens.Skill.Ets"],
+        operator_context: "Investigate memory leak"
+      }
+
+      assert {:ok, %ClassifyResult{intent: :investigation}} =
+               Zoi.parse(PipelineTools.classify_schema(), input)
+    end
+
+    test "synthesize_schema parses valid result" do
+      input = %{answer: "The system is healthy."}
+
+      assert {:ok, %SynthesizeResult{answer: "The system is healthy."}} =
+               Zoi.parse(PipelineTools.synthesize_schema(), input)
+    end
+  end
+end

--- a/test/beamlens/coordinator/strategy/pipeline_test.exs
+++ b/test/beamlens/coordinator/strategy/pipeline_test.exs
@@ -8,6 +8,11 @@ defmodule Beamlens.Coordinator.Strategy.PipelineTest do
   alias Beamlens.Coordinator.Strategy.Pipeline.Tools.{ClassifyResult, SynthesizeResult}
   alias Beamlens.Operator.Notification
 
+  setup do
+    start_supervised!({Registry, keys: :unique, name: Beamlens.OperatorRegistry})
+    :ok
+  end
+
   defp mock_client do
     Puck.Client.new({Puck.Backends.Mock, error: :test_stop})
   end

--- a/test/beamlens/telemetry_test.exs
+++ b/test/beamlens/telemetry_test.exs
@@ -22,10 +22,10 @@ defmodule Beamlens.TelemetryTest do
   end
 
   describe "event_names/0" do
-    test "returns all 51 event names" do
+    test "returns all 55 event names" do
       events = Telemetry.event_names()
 
-      assert length(events) == 51
+      assert length(events) == 55
     end
 
     test "all events start with :beamlens" do
@@ -48,6 +48,15 @@ defmodule Beamlens.TelemetryTest do
       assert [:beamlens, :operator, :started] in events
       assert [:beamlens, :operator, :notification_sent] in events
       assert [:beamlens, :operator, :state_change] in events
+    end
+
+    test "includes pipeline strategy events" do
+      events = Telemetry.event_names()
+
+      assert [:beamlens, :coordinator, :pipeline_classify_start] in events
+      assert [:beamlens, :coordinator, :pipeline_classify_complete] in events
+      assert [:beamlens, :coordinator, :pipeline_synthesize_start] in events
+      assert [:beamlens, :coordinator, :pipeline_synthesize_complete] in events
     end
   end
 

--- a/test/integration/pipeline_test.exs
+++ b/test/integration/pipeline_test.exs
@@ -1,0 +1,69 @@
+defmodule Beamlens.Integration.PipelineTest do
+  @moduledoc false
+
+  use Beamlens.IntegrationCase, async: false
+
+  alias Beamlens.Coordinator
+  alias Beamlens.Coordinator.Strategy.Pipeline
+
+  defp start_pipeline_coordinator(context, opts \\ []) do
+    name = :"pipeline_#{:erlang.unique_integer([:positive])}"
+
+    opts =
+      opts
+      |> Keyword.put(:name, name)
+      |> Keyword.put(:client_registry, context.client_registry)
+      |> Keyword.put(:strategy, Pipeline)
+
+    start_supervised({Coordinator, opts})
+  end
+
+  describe "pipeline classify → gather → synthesize" do
+    @tag timeout: 120_000
+    test "pipeline processes a simple question end-to-end", context do
+      ref = make_ref()
+      parent = self()
+
+      events = [
+        [:beamlens, :coordinator, :pipeline_classify_start],
+        [:beamlens, :coordinator, :pipeline_classify_complete],
+        [:beamlens, :coordinator, :pipeline_synthesize_start],
+        [:beamlens, :coordinator, :pipeline_synthesize_complete]
+      ]
+
+      for event <- events do
+        :telemetry.attach(
+          {ref, event},
+          event,
+          fn event_name, _measurements, metadata, _ ->
+            send(parent, {:telemetry, event_name, metadata})
+          end,
+          nil
+        )
+      end
+
+      on_exit(fn ->
+        for event <- events do
+          :telemetry.detach({ref, event})
+        end
+      end)
+
+      {:ok, pid} = start_pipeline_coordinator(context)
+
+      start_operator(context, skill: Beamlens.Skill.Beam)
+
+      result =
+        Coordinator.run(pid, %{reason: "What BEAM VM info can you see?"},
+          strategy: Pipeline,
+          timeout: 90_000,
+          deadline: 90_000,
+          skills: [Beamlens.Skill.Beam]
+        )
+
+      assert_receive {:telemetry, [:beamlens, :coordinator, :pipeline_classify_start], _}, 0
+      assert_receive {:telemetry, [:beamlens, :coordinator, :pipeline_classify_complete], _}, 0
+
+      assert {:ok, %{insights: _insights, operator_results: _results}} = result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `Pipeline` strategy that replaces the iterative agent loop with three focused stages: **classify** (single LLM call to determine intent and select skills), **gather** (invoke operators in parallel, await completion), and **synthesize** (single LLM call to produce a human-readable answer)
- Fewer, more focused LLM calls make it faster and cheaper than `AgentLoop` for straightforward queries
- Extends the `Strategy` behaviour with an optional `continue_loop/2` callback so custom strategies can control the full execution flow

## Changes

- **New files:** `Pipeline` strategy module, `Pipeline.Tools` for classify/synthesize result structs and Zoi schemas, `pipeline.baml` for BAML prompt functions
- **Coordinator:** Added Pipeline mention to moduledoc, inlined `function_exported?/3` check for `continue_loop/2`
- **Strategy behaviour:** Added optional `continue_loop/2` callback
- **Telemetry:** Documented 4 new pipeline events (`pipeline_classify_start/complete`, `pipeline_synthesize_start/complete`)
- **Architecture docs:** Added Pipeline strategy section with usage example
- **CHANGELOG:** Added entries for Pipeline strategy, `continue_loop/2` callback, and telemetry events

## Test plan

- [x] 857 unit tests pass (`mix test` — 0 failures)
- [x] Pipeline strategy unit tests cover classify, gather, and synthesize stages
- [x] Integration test verifies end-to-end pipeline flow
- [x] Telemetry test verifies pipeline event names are registered
- [x] Pre-release review agents pass clean (11 agents, 0 blocking issues)

Closes #65