### PR TITLE
Rename `function` key to `func` in Logger log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Logger skill: renamed `function` key to `func` in log entry maps to avoid collision with Lua's reserved `function` keyword, which caused repeated sandbox syntax errors and expensive context compaction
 - `CompletionResult` now derives `Jason.Encoder` so coordinator results can be JSON-encoded
 - Coordinator no longer crashes when the LLM returns an invalid or unparseable tool selection
 

--- a/lib/beamlens/skill/logger.ex
+++ b/lib/beamlens/skill/logger.ex
@@ -95,7 +95,7 @@ defmodule Beamlens.Skill.Logger do
 
     ### logger_recent(limit, level)
     Recent log entries. Level: "error", "warning", "info", "debug", or nil for all.
-    Returns: timestamp, level, message, module, function, line, domain
+    Returns: timestamp, level, message, module, func, line, domain
 
     ### logger_errors(limit)
     Recent error-level logs with full message content

--- a/lib/beamlens/skill/logger/log_store.ex
+++ b/lib/beamlens/skill/logger/log_store.ex
@@ -204,7 +204,7 @@ defmodule Beamlens.Skill.Logger.LogStore do
       level: level,
       message: format_message(msg),
       module: mod,
-      function: if(fun, do: "#{fun}/#{arity}"),
+      func: if(fun, do: "#{fun}/#{arity}"),
       line: Map.get(meta, :line),
       pid: Map.get(meta, :pid),
       domain: Map.get(meta, :domain, [])
@@ -298,7 +298,7 @@ defmodule Beamlens.Skill.Logger.LogStore do
       level: entry.level,
       message: entry.message,
       module: if(entry.module, do: inspect(entry.module)),
-      function: entry.function,
+      func: entry.func,
       line: entry.line,
       domain: entry.domain
     }

--- a/test/beamlens/skill/logger/log_store_test.exs
+++ b/test/beamlens/skill/logger/log_store_test.exs
@@ -69,7 +69,7 @@ defmodule Beamlens.Skill.Logger.LogStoreTest do
       assert logs == []
     end
 
-    test "log entries contain expected keys", %{store: _store} do
+    test "log entries use :func key instead of :function", %{store: _store} do
       capture_log(fn ->
         Logger.warning("shape test")
       end)
@@ -81,13 +81,8 @@ defmodule Beamlens.Skill.Logger.LogStoreTest do
         |> LogStore.get_logs(limit: 10)
         |> Enum.filter(&String.contains?(&1.message, "shape test"))
 
-      assert Map.has_key?(entry, :timestamp)
-      assert Map.has_key?(entry, :level)
-      assert Map.has_key?(entry, :message)
-      assert Map.has_key?(entry, :module)
-      assert Map.has_key?(entry, :func)
-      assert Map.has_key?(entry, :line)
-      assert Map.has_key?(entry, :domain)
+      assert %{timestamp: _, level: _, message: _, module: _, func: _, line: _, domain: _} = entry
+      refute Map.has_key?(entry, :function)
     end
 
     test "returns logs", %{store: _store} do

--- a/test/beamlens/skill/logger/log_store_test.exs
+++ b/test/beamlens/skill/logger/log_store_test.exs
@@ -69,6 +69,27 @@ defmodule Beamlens.Skill.Logger.LogStoreTest do
       assert logs == []
     end
 
+    test "log entries contain expected keys", %{store: _store} do
+      capture_log(fn ->
+        Logger.warning("shape test")
+      end)
+
+      LogStore.flush(@test_name)
+
+      [entry | _] =
+        @test_name
+        |> LogStore.get_logs(limit: 10)
+        |> Enum.filter(&String.contains?(&1.message, "shape test"))
+
+      assert Map.has_key?(entry, :timestamp)
+      assert Map.has_key?(entry, :level)
+      assert Map.has_key?(entry, :message)
+      assert Map.has_key?(entry, :module)
+      assert Map.has_key?(entry, :func)
+      assert Map.has_key?(entry, :line)
+      assert Map.has_key?(entry, :domain)
+    end
+
     test "returns logs", %{store: _store} do
       capture_log(fn ->
         Logger.warning("first")


### PR DESCRIPTION
## Summary
- Renames the `function` key to `func` in Logger log entries to avoid Lua reserved keyword conflicts
- The LLM-generated Lua sandbox code writes `entry.function`, which is a syntax error in Lua since `function` is reserved
- Each failure triggers retries and context compaction (~60s per cycle), turning 30s queries into 2+ minute timeouts

## Test plan
- [x] All 32 Logger and LogStore tests pass
- [x] Run Pipeline strategy query that exercises Logger operator to verify no more Lua syntax errors

Closes #68