### PR TITLE
Always return synthesized answer and use snapshot fallback data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pipeline strategy now always returns the synthesized answer as an insight, even when no operator notifications are raised
+- Pipeline synthesize stage uses operator snapshot data as fallback when no notifications are present, so the LLM can produce meaningful answers for healthy systems
 - Logger skill: renamed `function` key to `func` in log entry maps to avoid collision with Lua's reserved `function` keyword, which caused repeated sandbox syntax errors and expensive context compaction
 - `CompletionResult` now derives `Jason.Encoder` so coordinator results can be JSON-encoded
 - Coordinator no longer crashes when the LLM returns an invalid or unparseable tool selection


### PR DESCRIPTION
## Summary
- Pipeline strategy now always wraps the synthesized answer in an `Insight`, even when no operator notifications were raised — previously the answer was silently discarded for healthy systems
- When no notifications exist, operator snapshot data (always available) is passed to the synthesize LLM as fallback, so it can produce a meaningful answer instead of working from an empty data set

## Test plan
- [x] Updated existing "handles no notifications gracefully" test to assert insight IS created with the synthesized answer
- [x] Added new test verifying operator_results snapshot data is used as synthesize input when no notifications present
- [x] All 859 tests pass, Credo clean, precommit passes

Closes #70