### PR TITLE
Add out-of-scope guidance to Tracer system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tracer operator now exits immediately when the query is outside its tracing domain, instead of hallucinating invalid intents and exhausting retries
 - Pipeline strategy now always returns the synthesized answer as an insight, even when no operator notifications are raised
 - Pipeline synthesize stage uses operator snapshot data as fallback when no notifications are present, so the LLM can produce meaningful answers for healthy systems
 - Logger skill: renamed `function` key to `func` in log entry maps to avoid collision with Lua's reserved `function` keyword, which caused repeated sandbox syntax errors and expensive context compaction

--- a/lib/beamlens/skill/tracer.ex
+++ b/lib/beamlens/skill/tracer.ex
@@ -74,6 +74,11 @@ defmodule Beamlens.Skill.Tracer do
     - Message-limited sessions (50 traces max)
     - Time-limited sessions (60 seconds max)
 
+    ## Out of Scope
+    If the query is not about tracing specific function calls, call done() immediately.
+    You cannot inspect memory, processes, supervisors, ETS tables, or OS resources.
+    Other operators handle those domains.
+
     ## Safety Restrictions
     - You MUST specify a concrete arity (no wildcards)
     - High-frequency stdlib functions are blocked (send, ets, GenServer internals)

--- a/test/beamlens/skill/tracer_test.exs
+++ b/test/beamlens/skill/tracer_test.exs
@@ -28,6 +28,12 @@ defmodule Beamlens.Skill.TracerTest do
       assert String.contains?(prompt, "blocked")
       assert String.contains?(prompt, "arity")
     end
+
+    test "documents out-of-scope boundary" do
+      prompt = Tracer.system_prompt()
+      assert String.contains?(prompt, "Out of Scope")
+      assert String.contains?(prompt, "done()")
+    end
   end
 
   describe "snapshot/0" do


### PR DESCRIPTION
## Summary
- Adds an "Out of Scope" section to the Tracer operator's system prompt instructing the LLM to call `done()` immediately when the query isn't about function call tracing
- Explicitly states what the Tracer cannot do (memory, processes, supervisors, ETS, OS) so the LLM doesn't hallucinate intents like `get_node_info`

## Test plan
- [x] All 21 Tracer tests pass
- [x] Full suite (859 tests) passes, Credo clean, precommit passes
- [ ] Run Pipeline strategy query with Tracer to verify it exits quickly for non-tracing queries

Closes #67